### PR TITLE
Update hashes using reduceHash=True

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,56 @@
-# Patapon2HD
-Side Project for HD Patapon 2 textures
+<p align="center">
+  <a href="" rel="noopener">
+ <img width=420px height=150px src="https://upload.wikimedia.org/wikipedia/commons/a/af/Patapon_2_logo.png" alt="Patapon 2 logo"></a>
+</p>
+
+<h3 align="center">Patapon 2 HD</h3>
+
+<div align="center">
+
+[![Contributors](https://img.shields.io/github/contributors/shockturtle/Patapon2HD)](https://github.com/shockturtle/Patapon2HD/graphs/contributors)
+[![Stargazers](https://img.shields.io/github/stars/shockturtle/Patapon2HD)](https://github.com/shockturtle/Patapon2HD/stargazers)
+[![Issues](https://img.shields.io/github/issues/shockturtle/Patapon2HD.svg)](https://github.com/shockturtle/Patapon2HD/issues)
+[![Pull Requests](https://img.shields.io/github/issues-pr/shockturtle/Patapon2HD.svg)](https://github.com/shockturtle/Patapon2HD/pulls)
+
+</div>
+
+---
+
+Side Project for HD Patapon 2 textures.
 
 All textures are done entirely by me unless comments in textures.ini state otherwise.
 
-Put both the textures folder and textures.ini in memstick/psp/textures/GAME ID
+## 🎈 Usage <a name="usage"></a>
+
+To install, enable Texture Replacement in PPSSPP dev menu and put both the textures folder and textures.ini files in `PPSSPP/memstick/PSP/TEXTURES/%GAME_ID%`
 
 If the textures folder doesnt exist, make it.
 
-Common US Game ID: UCUS98732
+|  Region | Game ID     |
+| ------: | ----------- |
+|      EU | `UCES01177` |
+|      NA | `UCUS98732` |
+|      JP | `UCJS10089` |
+|      AS | `UCAS40239` |
 
-Common EU Game ID: UCES01177
 
-Common JP Game ID: UCJS10089
-
-
-
+## 🎉 Acknowledgements <a name = "acknowledgement"></a>
 BIG Thank you to
 
-owocek (Motivation)
+- [owocek](https://github.com/owocekTV) (Motivation)
 
-Xandis/Gat235 (Every single bird and javelin)
+- Xandis/Gat235 (Every single bird and javelin)
 
-Iracy (Materials and other items)
+- Iracy (Materials and other items)
 
-MitsukiHarune (Various symbols and high-quality resources)
+- MitsukiHarune (Various symbols and high-quality resources)
 
-efonte (Upscaling god)
+- [efonte](https://github.com/efonte) (AI Upscaling)
 
 
 Special Thanks to
 
-WallSoGB (Leader of the Patapon3Textures project)
+- [WallSoGB](https://github.com/WallSoGB) (Leader of the [Patapon3Textures](https://github.com/WallSoGB/Patapon3Textures) project)
 
 
 

--- a/textures.ini
+++ b/textures.ini
@@ -1,774 +1,775 @@
 [options]
-#created by shockturtle
-#assisted by many people, including iracy, xandis, owocek, mitsuki, wallsogb
+# Created by shockturtle
+# assisted by many people, including iracy, xandis, owocek, mitsuki, wallsogb
 version = 1
 hash = xxh64
 ignoreAddress = True
 ignoreMipmap = True
+reduceHash = True
 [hashes]
 
-#--Font--#
-00000000a3bd321c380b6695 = textures/font/text1.png
-00000000e98bf3a8380b6695 = textures/font/text2.png
-000000003c623cfa380b6695 = textures/font/text3.png
-#thanks to mitsuki for creating the euro and pound symbols. https://www.deviantart.com/mitsukiharune
-#000000005e0a6c5b3f84b044 = textures/font/jp1.png
-#000000006c2d47543f84b044 = textures/font/jp2.png
-#00000000097061723f84b044 = textures/font/jp3.png
-#0000000031d85fb03a3ff991 = textures/font/jp4.png
-#000000006a196c8b02257f79 = textures/font/jp5.png
-#00000000d72d18238dce0fb6 = textures/font/jp6.png
-#000000005db002708dce0fb6 = textures/font/jp7.png
-#00000000b12a7bce07c70c77 = textures/font/jp8.png
-#00000000bd9b961007c70c77 = textures/font/jp9.png
-#00000000b12a7bdec89e6430 = textures/font/jp10.png
-#00000000395cd4ca629f2cb0 = textures/font/jp11.png
-#00000000406f477e629f2cb0 = textures/font/jp12.png
-#0000000000000909bd35819c = textures/font/jp13.png
+# --Font--
+00000000a3bd321ca2ed3327 = textures/font/text1.png
+00000000e98bf3a8a2ed3327 = textures/font/text2.png
+000000003c623cfaa2ed3327 = textures/font/text3.png
+# thanks to mitsuki for creating the euro and pound symbols. https://www.deviantart.com/mitsukiharune
+# HASH_TO_UPDATE_000000005e0a6c5b3f84b044 = textures/font/jp1.png
+# HASH_TO_UPDATE_000000006c2d47543f84b044 = textures/font/jp2.png
+# HASH_TO_UPDATE_00000000097061723f84b044 = textures/font/jp3.png
+# HASH_TO_UPDATE_0000000031d85fb03a3ff991 = textures/font/jp4.png
+# HASH_TO_UPDATE_000000006a196c8b02257f79 = textures/font/jp5.png
+# HASH_TO_UPDATE_00000000d72d18238dce0fb6 = textures/font/jp6.png
+# HASH_TO_UPDATE_000000005db002708dce0fb6 = textures/font/jp7.png
+# HASH_TO_UPDATE_00000000b12a7bce07c70c77 = textures/font/jp8.png
+# HASH_TO_UPDATE_00000000bd9b961007c70c77 = textures/font/jp9.png
+# HASH_TO_UPDATE_00000000b12a7bdec89e6430 = textures/font/jp10.png
+# HASH_TO_UPDATE_00000000395cd4ca629f2cb0 = textures/font/jp11.png
+# HASH_TO_UPDATE_00000000406f477e629f2cb0 = textures/font/jp12.png
+# HASH_TO_UPDATE_0000000000000909bd35819c = textures/font/jp13.png
 
-#--User Interface--#
-#us
-00000000cd9d690b76244193 = textures/ui/controls.png
-#uk
-000000008c87cfc8c7a06431 = textures/ui/controls.png
-#jp
-#nothing here yet
-#all
-#000000008109e2a8f5401fc2 = textures/ui/classes.png
-00000000cf992a55a451870b = textures/ui/L_and_R.png
-000000002313f6674eeee3b3 = textures/ui/bubble.png
-00000000702399226327b023 = textures/ui/buttons.png
-00000000e37dd062abae98af = textures/ui/cursor.png
-00000000cc46545ba82b1a44 = textures/ui/loadingpon.png
-000000008a4bd584d075a562 = textures/ui/waitingpon.png
-00000000a639241b1b1ca9bc = textures/ui/sharepon.png
-000000005d8ffc3079135679 = textures/ui/immunities.png
-00000000ce30d0d7cbc7c67b = textures/ui/drums.png
-#Worldmap
-00000000d949610769cd7656 = textures/map/mission_bubble.png
-000000001a4987045f9497fc = textures/map/worldmap.png
-0000000032881db4d9713832 = textures/map/mapicon1.png
-0000000060a5f9ff29da1863 = textures/map/mapicon2.png
-00000000004dcaa62856ad1b = textures/map/mapicon3.png
-00000000e89f94ddd75fd94a = textures/map/mapicon4.png
+# --User Interface--
+# us
+00000000cd9d690b35f6db4b = textures/ui/controls.png
+# uk
+000000008c87cfc8451c4217 = textures/ui/controls.png
+# jp
+# nothing here yet
+# all
+# HASH_TO_UPDATE_000000008109e2a8f5401fc2 = textures/ui/classes.png
+00000000cf992a558bb85222 = textures/ui/L_and_R.png
+000000002313f66768274c16 = textures/ui/bubble.png
+0000000070239922f04bd678 = textures/ui/buttons.png
+00000000e37dd062b2a37836 = textures/ui/cursor.png
+00000000cc46545b7c508ba3 = textures/ui/loadingpon.png
+000000008a4bd58439978937 = textures/ui/waitingpon.png
+# HASH_TO_UPDATE_00000000a639241b1b1ca9bc = textures/ui/sharepon.png
+000000005d8ffc3082e9e25d = textures/ui/immunities.png
+00000000ce30d0d7f291e1d5 = textures/ui/drums.png
+# Worldmap
+00000000d94961075040bc83 = textures/map/mission_bubble.png
+000000001a4987046ad58204 = textures/map/worldmap.png
+0000000032881db49d3ff0e3 = textures/map/mapicon1.png
+0000000060a5f9ff07e2d02b = textures/map/mapicon2.png
+00000000004dcaa6ceae5e18 = textures/map/mapicon3.png
+00000000e89f94ddb891e748 = textures/map/mapicon4.png
 
-#--Title Screen--#
-#us
-0000000012973960b524ee57 = textures/titlescreen/sony.png
-000000002f4be5ac65de7423 = textures/titlescreen/labo2_us.png
-00000000eb92c788e46eaeba = textures/titlescreen/options_us.png
-#uk
-0000000012973960b524ee57 = textures/titlescreen/sony.png
-0000000051fb07a1f2ee2622 = textures/titlescreen/labo2_uk.png
-00000000f07a4a9781c5b6c7 = textures/titlescreen/options_uk.png
-#jp
-0000000012973960906e86a5 = textures/titlescreen/sony.png
-00000000270129fe871308a5 = textures/titlescreen/labo2_jp.png
-#00000000e217c8632d52acdf = textures/titlescreen/options_jp.png
+# --Title Screen--
+# us
+000000001297396087eefda2 = textures/titlescreen/sony.png
+000000002f4be5ac2a458de6 = textures/titlescreen/labo2_us.png
+00000000eb92c78866664765 = textures/titlescreen/options_us.png
+# uk
+# HASH_TO_UPDATE_0000000012973960b524ee57 = textures/titlescreen/sony.png
+0000000051fb07a1b5a0f0a6 = textures/titlescreen/labo2_uk.png
+# HASH_TO_UPDATE_00000000f07a4a9781c5b6c7 = textures/titlescreen/options_uk.png
+# jp
+# HASH_TO_UPDATE_0000000012973960906e86a5 = textures/titlescreen/sony.png
+# HASH_TO_UPDATE_00000000270129fe871308a5 = textures/titlescreen/labo2_jp.png
+# HASH_TO_UPDATE_00000000e217c8632d52acdf = textures/titlescreen/options_jp.png
 
-#--Patapolis--#
-0000000096fde4b7eea563f8 = textures/patapolis/citizens.png
-00000000ff323c144886336f = textures/patapolis/citizens_p1.png
-000000002650d49612030250 = textures/patapolis/yapon.png
-00000000883e8fb851a2c421 = textures/patapolis/tsukupon.png
-00000000492b959663708d46 = textures/patapolis/meden.png
-00000000d4bb9e50471d3e87 = textures/patapolis/altar.png
-0000000078ae418ae1da28a4 = textures/patapolis/obelisk.png
-00000000622a56a2ae0a1e30 = textures/patapolis/patagate.png
-0000000040ebe98fd6a343ce = textures/patapolis/festival.png
-000000001ad659a90e092a9c = textures/patapolis/festival_glow.png
-00000000482a286927b615d0 = textures/patapolis/colonybg.png
-00000000030519593e6c7342 = textures/patapolis/colonybg2.png
-00000000a10e43d3e06faafa = textures/patapolis/mater.png
-00000000fadf150d20339419 = textures/patapolis/mater_menu.png
-#00000000d228aa72911857d0 = textures/patapolis/materglow.png
-#0000000091b7c636e648a378 = textures/patapolis/mater_dirt.png
-#00000000a652f06059cc2aee = textures/patapolis/citcap1.png
-#00000000c54509bb7e3ccae4 = textures/patapolis/citcap2.png
-#0000000026597b736086b0b7 = textures/patapolis/citcap3.png
-0000000076ec01192f8f64ae = textures/patapolis/jar.png
-0000000051f5abb7e50101b4 = textures/patapolis/plate.png
-#the following texture is a placeholder!
-00000000ca322c1e9005e054 = textures/patapolis/meat.png
-000000004f6ce0050141e65d = textures/patapolis/shovel.png
-0000000091b7c636e648a378 = textures/patapolis/dirt.png
-#000000002825aacd0c8a30c3 = textures/patapolis/bunnypon.png
-00000000d164168e4476fe2c = textures/patapolis/festivalhat1.png
-0000000061b6edbe001a29f8 = textures/patapolis/festivalhat2.png
-#000000007cd4cf87781df01d = textures/patapolis/festivalstaff.png
-000000001569206f5cc07d0f = textures/patapolis/festivalironspear.png
+# --Patapolis--
+0000000096fde4b73d7c252c = textures/patapolis/citizens.png
+00000000ff323c14633fc661 = textures/patapolis/citizens_p1.png
+000000002650d49665009fa6 = textures/patapolis/yapon.png
+00000000883e8fb8398ac727 = textures/patapolis/tsukupon.png
+00000000492b9596b26998ef = textures/patapolis/meden.png
+00000000d4bb9e504578a2e3 = textures/patapolis/altar.png
+0000000078ae418af40ec2a1 = textures/patapolis/obelisk.png
+00000000622a56a25ab61932 = textures/patapolis/patagate.png
+0000000040ebe98f50e375bf = textures/patapolis/festival.png
+000000001ad659a98d00abb9 = textures/patapolis/festival_glow.png
+00000000482a2869ea0d529b = textures/patapolis/colonybg.png
+000000000305195929501d1f = textures/patapolis/colonybg2.png
+00000000a10e43d3818903dc = textures/patapolis/mater.png
+00000000fadf150d47287a33 = textures/patapolis/mater_menu.png
+# 00000000d228aa7283ac12fa = textures/patapolis/materglow.png
+# 0000000091b7c6363af7fef7 = textures/patapolis/mater_dirt.png
+# 00000000a652f0609d75574c = textures/patapolis/citcap1.png
+# 00000000c54509bb0431f1ee = textures/patapolis/citcap2.png
+# 0000000026597b73fe6760b2 = textures/patapolis/citcap3.png
+0000000076ec0119b85b018b = textures/patapolis/jar.png
+0000000051f5abb77947268e = textures/patapolis/plate.png
+# the following texture is a placeholder!
+00000000ca322c1eaeaf0c27 = textures/patapolis/meat.png
+000000004f6ce005650ba94a = textures/patapolis/shovel.png
+# HASH_TO_UPDATE_0000000091b7c636e648a378 = textures/patapolis/dirt.png
+# 000000002825aacdd6824359 = textures/patapolis/bunnypon.png
+00000000d164168eeffccd65 = textures/patapolis/festivalhat1.png
+0000000061b6edbe74182644 = textures/patapolis/festivalhat2.png
+# 000000007cd4cf87ca0a82f2 = textures/patapolis/festivalstaff.png
+000000001569206fe3b9cf87 = textures/patapolis/festivalironspear.png
 
-#--Equipment--#
-#Masks#
-00000000f000af8de0906a71 = textures/eq/mask/sutata.png
-0000000013415b53d427a958 = textures/eq/mask/suttata.png
-0000000058fd7651438e4be7 = textures/eq/mask/sutatattan.png
-00000000ae5baa6042b4b3ab = textures/eq/mask/sutatanooo.png
-00000000a9302c47a9d9cc29 = textures/eq/mask/sutata_deka.png
-00000000f5ed9ca138ed06be = textures/eq/mask/suttata_deka.png
-00000000d604724d74ae0a20 = textures/eq/mask/sutatattan_deka.png
-00000000fd91bb0d0374edd9 = textures/eq/mask/sutatanooo_deka.png
-000000001c8471d41a51fb4a = textures/eq/mask/gashishi.png
-00000000dadcb9c5d46f9835 = textures/eq/mask/gasshin.png
-00000000d4082dd2c8726ed3 = textures/eq/mask/zugashi.png
-000000006d2acda616fb97fc = textures/eq/mask/gasshingaa.png
-000000007e78924059314b33 = textures/eq/mask/gashishi_deka.png
-000000001cfa7083ed6231b3 = textures/eq/mask/gasshin_deka.png
-00000000f5192579e1d23238 = textures/eq/mask/zugashi_deka.png
-0000000064144c572bde6ea9 = textures/eq/mask/gasshingaa_deka.png
-00000000c58db002cbcabb77 = textures/eq/mask/gochichi.png
-00000000644fa3a816744e5c = textures/eq/mask/gocchin.png
-000000003442afea6cade2ad = textures/eq/mask/cocchinko.png
-000000003f565126ef968acd = textures/eq/mask/gochigachidesu.png
-00000000e9d9589f7bdf04d3 = textures/eq/mask/gochichi_deka.png
-0000000003cd3f3f607bcd68 = textures/eq/mask/gocchin_deka.png
-0000000028de0d1e865e2c18 = textures/eq/mask/cocchinko_deka.png
-00000000e4042c9103c01c9d = textures/eq/mask/gochigachidesu_deka.png
-00000000d57dc06ee97782d8 = textures/eq/mask/shuba.png
-0000000057e720508426682a = textures/eq/mask/shubaba.png
-00000000d5e02519107aaa9f = textures/eq/mask/shubabiya.png
-00000000a59690d00a4edf29 = textures/eq/mask/shubabassa.png
-0000000047bc5558b953c392 = textures/eq/mask/shuba_deka.png
-0000000075dbebd772770ce3 = textures/eq/mask/shubaba_deka.png
-000000007af0fa796361d948 = textures/eq/mask/shubabiya_deka.png
-000000003163027df97344ae = textures/eq/mask/shubabassa_deka.png
-00000000d70f915824df3286 = textures/eq/mask/bishiri.png
-0000000063de44a1f65f1ea0 = textures/eq/mask/bisharin.png
-0000000066ae04b992104274 = textures/eq/mask/donpisha.png
-00000000677cc39d3394bb21 = textures/eq/mask/dopishana.png
-00000000676209b9ffd48ca2 = textures/eq/mask/bishiri_deka.png
-00000000f87c0345eb95caab = textures/eq/mask/bisharin_deka.png
-00000000e3c0e3e6aa8e30dd = textures/eq/mask/donpisha_deka.png
-0000000039b306f367439482 = textures/eq/mask/dopishana_deka.png
-00000000b995743729dcd385 = textures/eq/mask/gurara.png
-000000007bff9d225ddb4a3f = textures/eq/mask/guraran.png
-00000000e118770f63e5dff2 = textures/eq/mask/guranguran.png
-000000009203271fa136b39b = textures/eq/mask/gurarandaa.png
-00000000ee8e0a2b35e6266d = textures/eq/mask/gurara_deka.png
-00000000f5f18d6330f6a0b9 = textures/eq/mask/guraran_deka.png
-00000000150d624c0972347f = textures/eq/mask/guranguran_deka.png
-000000006499366228d2ad9b = textures/eq/mask/gurarandaa_deka.png
-00000000cd3de43336c6e9ab = textures/eq/mask/ototo.png
-000000000b261f992cde45fa = textures/eq/mask/ottoto.png
-000000009f5752adc64d89ef = textures/eq/mask/ottototo.png
-000000003a33d446a61fa8f9 = textures/eq/mask/ototodokko.png
-000000004013ad51243485c6 = textures/eq/mask/ototo_deka.png
-0000000059c6051b9dbe074c = textures/eq/mask/ottoto_deka.png
-00000000895774e55c737690 = textures/eq/mask/ottototo_deka.png
-00000000c642defe54bb708d = textures/eq/mask/ototodokko_deka.png
-0000000020e8d57fccd01d03 = textures/eq/mask/merara.png
-000000009ecb7775f7f125b5 = textures/eq/mask/meracchi.png
-00000000960eb4a837b7e9c3 = textures/eq/mask/meraachichi.png
-00000000276ea57624bd6d43 = textures/eq/mask/meraachiize.png
-000000007ed32b7bd6fc1ef0 = textures/eq/mask/merara_deka.png
-000000007ebcadf6f2b8818a = textures/eq/mask/meracchi_deka.png
-00000000f8fe57ac9e10d269 = textures/eq/mask/meraachichi_deka.png
-000000001da1ae7392b433b5 = textures/eq/mask/meraachiize_deka.png
-000000005ff3d3028eb84a27 = textures/eq/mask/kachichi.png
-000000000d7188359f1950f9 = textures/eq/mask/kachikochi.png
-000000007ca7672e554c45ed = textures/eq/mask/kachinkon.png
-00000000d05cb78cd3d18808 = textures/eq/mask/kacchikochin.png
-00000000ac8ecca0321674bb = textures/eq/mask/kachichi_deka.png
-000000006fb33c90b5e345b6 = textures/eq/mask/kachikochi_deka.png
-00000000396f59bef0ce3cc9 = textures/eq/mask/kachinkon_deka.png
-00000000fa4a1c8439a3502d = textures/eq/mask/kacchikochin_deka.png
-00000000d3b7d7578925ac0e = textures/eq/mask/nekoro.png
-0000000075a01b5a0e24088f = textures/eq/mask/nenkoro.png
-00000000b26a0f19684783cb = textures/eq/mask/nenkorori.png
-00000000ceee1fc624ba6afc = textures/eq/mask/nekororinyo.png
-000000000434cdb7e1c48220 = textures/eq/mask/nekoro_deka.png
-000000007742f6f4c33b3874 = textures/eq/mask/nenkoro_deka.png
-000000005f9157a117aa2b6b = textures/eq/mask/nenkorori_deka.png
-0000000090875fbbe0daae6e = textures/eq/mask/nekororinyo_deka.png
-000000005b671b2b03f905b1 = textures/eq/mask/kakin.png
-000000001e3785930ca82747 = textures/eq/mask/kakikoki.png
-00000000db1aea9c6faacaf7 = textures/eq/mask/kakkinko.png
-00000000812b4b6928b27ca9 = textures/eq/mask/kakkokingu.png
-00000000295edac820bc37e0 = textures/eq/mask/kakin_deka.png
-000000005a78c5e237f8db6d = textures/eq/mask/kakikoki_deka.png
-00000000e1c2c3a3d06e5877 = textures/eq/mask/kakkinko_deka.png
-000000008596dac81dc3b4d1 = textures/eq/mask/kakkokingu_deka.png
-00000000e19733f9bba3a964 = textures/eq/mask/hirara.png
-000000007e56fc7cf7823c1f = textures/eq/mask/hirarin.png
-000000006652b02a4b85d430 = textures/eq/mask/hiraratto.png
-000000009fe1361ffd45278c = textures/eq/mask/hirarinmaru.png
-00000000bb184d76c08844b0 = textures/eq/mask/hirara_deka.png
-00000000a24783b06cf514ce = textures/eq/mask/hirarin_deka.png
-000000006bbf65834610ae73 = textures/eq/mask/hiraratto_deka.png
-000000001f048e5279a6d07d = textures/eq/mask/hirarinmaru_deka.png
-0000000091d978ccf09a968b = textures/eq/mask/biyoyo.png
-00000000416721d1b4b85ead = textures/eq/mask/biyoyon.png
-00000000af6d845c0fe77e1a = textures/eq/mask/byororon.png
-00000000508590d158f3a4b8 = textures/eq/mask/babyobyon.png
-00000000340d54c103a0e85f = textures/eq/mask/biyoyo_deka.png
-00000000aa7a9109e7245cec = textures/eq/mask/biyoyon_deka.png
-00000000b2d4b7a1ac16e74a = textures/eq/mask/byororon_deka.png
-00000000effbe2f31b683a30 = textures/eq/mask/babyobyon_deka.png
-00000000102157c5d188fd2a = textures/eq/mask/doshishi.png
-0000000012044c0966e1178d = textures/eq/mask/dosshiri.png
-00000000181341eeddc8932d = textures/eq/mask/zundoshiri.png
-0000000085d896222f27acc4 = textures/eq/mask/doshirittan.png
-0000000057bdd03119fb4077 = textures/eq/mask/doshishi_deka.png
-0000000068d98e3dadf693f2 = textures/eq/mask/dosshiri_deka.png
-00000000d052a08bd078ae0f = textures/eq/mask/zundoshiri_deka.png
-00000000ed49b2ae05ded77e = textures/eq/mask/doshirittan_deka.png
-000000009ac1df64b2a10add = textures/eq/mask/shitoto.png
-0000000043b9cd715b1c6019 = textures/eq/mask/shitton.png
-00000000f7b919a54c12d241 = textures/eq/mask/shittoriyo.png
-000000002930921ac725dbfd = textures/eq/mask/shittorrine.png
-00000000b07cb994506c8453 = textures/eq/mask/shitoto_deka.png
-000000000d86eadb435fadb3 = textures/eq/mask/shitton_deka.png
-000000001eb84d58d80c38e5 = textures/eq/mask/shittoriyo_deka.png
-000000007ee530bbb61b2c79 = textures/eq/mask/shittorrine_deka.png
-0000000061cac60254aed2ab = textures/eq/mask/meranya.png
-000000007209520f67bb5ab8 = textures/eq/mask/nameranya.png
-0000000043325f458e031308 = textures/eq/mask/dameranya.png
-000000009278d820c0cc0333 = textures/eq/mask/dameranyan.png
-000000005052dd98afb2ea2e = textures/eq/mask/meranya_deka.png
-000000006cc0789f00aa8282 = textures/eq/mask/nameranya_deka.png
-00000000a49d5345157c9c75 = textures/eq/mask/dameranya_deka.png
-000000006adb7fcd026fe330 = textures/eq/mask/dameranyan_deka.png
-000000003f3d970e2a306f80 = textures/eq/mask/popoka.png
-000000006595630846e0640a = textures/eq/mask/pokapoka.png
-0000000037141ec119f9f9f9 = textures/eq/mask/popopokka.png
-000000007b4421c4f7c907ff = textures/eq/mask/poppkaana.png
-00000000a7ea10c04dca3cb4 = textures/eq/mask/popoka_deka.png
-000000009d9a3016c37f8454 = textures/eq/mask/pokapoka_deka.png
-000000000bfda3b1d3c27345 = textures/eq/mask/popopokka_deka.png
-0000000064fdab9419ba4751 = textures/eq/mask/poppkaana_deka.png
-000000000b5dd824ba3dd15f = textures/eq/mask/nonburu.png
-00000000fc74e7158af07d3c = textures/eq/mask/nonbururu.png
-00000000d3a94ff140417975 = textures/eq/mask/nonnooburu.png
-000000001767f23a656f00ac = textures/eq/mask/nonburussa.png
-000000003ffe7ab690d35199 = textures/eq/mask/nonburu_deka.png
-000000009a84ca74a3968608 = textures/eq/mask/nonbururu_deka.png
-000000000bd34a14c61d6263 = textures/eq/mask/nonnooburu_deka.png
-00000000c7c9baab0951e23d = textures/eq/mask/nonburussa_deka.png
-00000000327e375e36169c67 = textures/eq/mask/babiri.png
-00000000d158c3609ed6acde = textures/eq/mask/babirira.png
-00000000eaee5cf2036b3e52 = textures/eq/mask/babiriino.png
-0000000044567ae531699dcb = textures/eq/mask/babinonnon.png
-000000004b475f4e9eea2256 = textures/eq/mask/babiri_deka.png
-000000004b8491b86935358a = textures/eq/mask/babirira_deka.png
-00000000a474718b825cf63b = textures/eq/mask/babiriino_deka.png
-000000006ad94f57836922f5 = textures/eq/mask/babinonnon_deka.png
-000000004941dca6eed33414 = textures/eq/mask/jirin.png
-00000000bae129bb82b98fbc = textures/eq/mask/jiririn.png
-0000000001257eaa464e86af = textures/eq/mask/jinjirin.png
-00000000a4ca60bfd841d4dd = textures/eq/mask/jiririntan.png
-00000000f99cb1ca8b985995 = textures/eq/mask/jirin_deka.png
-0000000064a96b50ca2350a2 = textures/eq/mask/jiririn_deka.png
-0000000014659fde5cb63134 = textures/eq/mask/jinjirin_deka.png
-000000006116573d8cc3cf9b = textures/eq/mask/jiririntan_deka.png
-00000000d4c6cc9b6db5060a = textures/eq/mask/zubaba.png
-0000000028d9ffa3d0a98029 = textures/eq/mask/zubizuba.png
-0000000029f2080a70a88340 = textures/eq/mask/zunzunbiba.png
-00000000537f6dbb6287beb4 = textures/eq/mask/zubizubabaya.png
-0000000073c8a2452ebfc141 = textures/eq/mask/zubaba_deka.png
-000000003ce7407a2adfa20d = textures/eq/mask/zubizuba_deka.png
-00000000d73254c17a218bbd = textures/eq/mask/zunzunbiba_deka.png
-00000000c573dca224c66ca0 = textures/eq/mask/zubizubabaya_deka.png
-00000000e49151f3e2d45791 = textures/eq/mask/kachiko.png
-0000000096cfe4f421dbdad0 = textures/eq/mask/kachikochi_unique.png
-00000000faab7d331d590c67 = textures/eq/mask/kacchinko.png
-0000000000f14d5d7512f4e0 = textures/eq/mask/kachinkocchi.png
-000000001a563548ce00072f = textures/eq/mask/kachiko_deka.png
-000000005014e9efd2a01005 = textures/eq/mask/kachikochi_unique_deka.png
-00000000856dd107dcb59e5a = textures/eq/mask/kacchinko_deka.png
-00000000875fb8ea7c826dc9 = textures/eq/mask/kachinkocchi_deka.png
-00000000d56621fc1a986294 = textures/eq/mask/myuu.png
-000000004d812be9c32a4eab = textures/eq/mask/myuuto.png
-0000000002bde5d6c16e567b = textures/eq/mask/myuutan.png
-000000002670cc2d31a2f593 = textures/eq/mask/myuutaron.png
-00000000166ed7e337368341 = textures/eq/mask/myuu_deka.png
-000000005f5783bc1512865f = textures/eq/mask/myuuto_deka.png
-000000007463aedd280821a3 = textures/eq/mask/myuutan_deka.png
-00000000f2296b30be519e46 = textures/eq/mask/myuutaron_deka.png
-00000000ae3c26ad165839ce = textures/eq/mask/dogyuun.png
-000000000307edb0b21c4cc1 = textures/eq/mask/dongyugyu.png
-000000008aa78bb652644791 = textures/eq/mask/dodongyuu.png
-00000000abdfacd4b8425c5d = textures/eq/mask/zuddongyu.png
-00000000d3671b0e583b5418 = textures/eq/mask/dogyuun_deka.png
-00000000aaa306f7ecc7fabf = textures/eq/mask/dongyugyu_deka.png
-000000009e2a7529119dc4a1 = textures/eq/mask/dodongyuu_deka.png
-00000000438ea41996300150 = textures/eq/mask/zuddongyu_deka.png
-00000000c34ccdf6a0ee9a94 = textures/eq/mask/subasara.png
-000000004ab158419f5e4d28 = textures/eq/mask/rabasara.png
-000000001e39b94b7bbd7c2d = textures/eq/mask/raparassa.png
-00000000b7ff2e90c11b0cf9 = textures/eq/mask/rapasaraana.png
-00000000c79000e1ffc2927f = textures/eq/mask/subasara_deka.png
-00000000e3728368f94729d7 = textures/eq/mask/rabasara_deka.png
-00000000ed8625f7800a41f4 = textures/eq/mask/raparassa_deka.png
-00000000adf843da99146225 = textures/eq/mask/rapasaraana_deka.png
-00000000e548ec02aa906df0 = textures/eq/mask/karmen_mask_1.png
-00000000432636f50ff49f14 = textures/eq/mask/karmen_mask_2.png
-000000003aaefa1aa458bf86 = textures/eq/mask/karmen_mask_3.png
-00000000aed3133fa973f68f = textures/eq/mask/karmen_mask_4.png
-000000007061b6aec064ff3f = textures/eq/mask/karmen_mask_5.png
-000000005298607ec57f3b0d = textures/eq/mask/dark_mask.png
+# --Equipment--
+# Masks
+00000000f000af8d53b645a9 = textures/eq/mask/sutata.png
+0000000013415b53c49e194c = textures/eq/mask/suttata.png
+0000000058fd765176f508ab = textures/eq/mask/sutatattan.png
+00000000ae5baa60f72f9b8c = textures/eq/mask/sutatanooo.png
+00000000a9302c47974d6a90 = textures/eq/mask/sutata_deka.png
+00000000f5ed9ca1d4207db1 = textures/eq/mask/suttata_deka.png
+00000000d604724d9692af50 = textures/eq/mask/sutatattan_deka.png
+00000000fd91bb0debd96aae = textures/eq/mask/sutatanooo_deka.png
+000000001c8471d4d33a28d1 = textures/eq/mask/gashishi.png
+00000000dadcb9c527595ec5 = textures/eq/mask/gasshin.png
+00000000d4082dd241d672e0 = textures/eq/mask/zugashi.png
+000000006d2acda6752d2ddf = textures/eq/mask/gasshingaa.png
+000000007e789240aeba413b = textures/eq/mask/gashishi_deka.png
+000000001cfa70838341d7b3 = textures/eq/mask/gasshin_deka.png
+00000000f5192579d7ded73f = textures/eq/mask/zugashi_deka.png
+0000000064144c574b08c825 = textures/eq/mask/gasshingaa_deka.png
+00000000c58db002434b4bb5 = textures/eq/mask/gochichi.png
+00000000644fa3a8ec07c9a5 = textures/eq/mask/gocchin.png
+000000003442afea7257dab2 = textures/eq/mask/cocchinko.png
+000000003f5651267658a876 = textures/eq/mask/gochigachidesu.png
+00000000e9d9589f074e4af0 = textures/eq/mask/gochichi_deka.png
+0000000003cd3f3f38be93ee = textures/eq/mask/gocchin_deka.png
+0000000028de0d1e3d3d9f6d = textures/eq/mask/cocchinko_deka.png
+00000000e4042c911d7f708e = textures/eq/mask/gochigachidesu_deka.png
+00000000d57dc06ea049c7d6 = textures/eq/mask/shuba.png
+0000000057e72050df625bc9 = textures/eq/mask/shubaba.png
+00000000d5e02519fb768b95 = textures/eq/mask/shubabiya.png
+00000000a59690d08db64cc6 = textures/eq/mask/shubabassa.png
+0000000047bc55580422a813 = textures/eq/mask/shuba_deka.png
+0000000075dbebd7fe818f14 = textures/eq/mask/shubaba_deka.png
+000000007af0fa79446f2347 = textures/eq/mask/shubabiya_deka.png
+000000003163027d32be9a21 = textures/eq/mask/shubabassa_deka.png
+00000000d70f91588c9179dd = textures/eq/mask/bishiri.png
+0000000063de44a1927417b7 = textures/eq/mask/bisharin.png
+0000000066ae04b93c7c4705 = textures/eq/mask/donpisha.png
+00000000677cc39d0feaba5e = textures/eq/mask/dopishana.png
+00000000676209b9d9c4b929 = textures/eq/mask/bishiri_deka.png
+00000000f87c0345e019e5ed = textures/eq/mask/bisharin_deka.png
+00000000e3c0e3e67727b6f3 = textures/eq/mask/donpisha_deka.png
+0000000039b306f3f2a1850a = textures/eq/mask/dopishana_deka.png
+00000000b9957437415304ae = textures/eq/mask/gurara.png
+000000007bff9d22f0bafd4f = textures/eq/mask/guraran.png
+00000000e118770fad4fd2c6 = textures/eq/mask/guranguran.png
+000000009203271fa8b7e78c = textures/eq/mask/gurarandaa.png
+00000000ee8e0a2b2d746dec = textures/eq/mask/gurara_deka.png
+00000000f5f18d638051dcaa = textures/eq/mask/guraran_deka.png
+00000000150d624cbff284ad = textures/eq/mask/guranguran_deka.png
+00000000649936624f2f2309 = textures/eq/mask/gurarandaa_deka.png
+00000000cd3de433949ea4b0 = textures/eq/mask/ototo.png
+000000000b261f99657cde0d = textures/eq/mask/ottoto.png
+000000009f5752ad90a49f8c = textures/eq/mask/ottototo.png
+000000003a33d446b941d3be = textures/eq/mask/ototodokko.png
+000000004013ad51de65502d = textures/eq/mask/ototo_deka.png
+0000000059c6051b83b7abe3 = textures/eq/mask/ottoto_deka.png
+00000000895774e59defc6a2 = textures/eq/mask/ottototo_deka.png
+00000000c642defe7e0476e7 = textures/eq/mask/ototodokko_deka.png
+0000000020e8d57f30d36b34 = textures/eq/mask/merara.png
+000000009ecb777570308f35 = textures/eq/mask/meracchi.png
+00000000960eb4a82f1e68c0 = textures/eq/mask/meraachichi.png
+00000000276ea576d7f9bc61 = textures/eq/mask/meraachiize.png
+000000007ed32b7bde368d57 = textures/eq/mask/merara_deka.png
+000000007ebcadf691853592 = textures/eq/mask/meracchi_deka.png
+00000000f8fe57ac1b810466 = textures/eq/mask/meraachichi_deka.png
+000000001da1ae730b6f4302 = textures/eq/mask/meraachiize_deka.png
+000000005ff3d30249168abd = textures/eq/mask/kachichi.png
+000000000d7188350e68bbdc = textures/eq/mask/kachikochi.png
+000000007ca7672e5c4d373f = textures/eq/mask/kachinkon.png
+00000000d05cb78cc0b50aad = textures/eq/mask/kacchikochin.png
+00000000ac8ecca018cc355d = textures/eq/mask/kachichi_deka.png
+000000006fb33c90187beade = textures/eq/mask/kachikochi_deka.png
+00000000396f59be59d30be6 = textures/eq/mask/kachinkon_deka.png
+00000000fa4a1c8455642312 = textures/eq/mask/kacchikochin_deka.png
+00000000d3b7d757768cf531 = textures/eq/mask/nekoro.png
+0000000075a01b5a91b40198 = textures/eq/mask/nenkoro.png
+00000000b26a0f197f6e8e24 = textures/eq/mask/nenkorori.png
+00000000ceee1fc6bff53f59 = textures/eq/mask/nekororinyo.png
+000000000434cdb7c9471cb6 = textures/eq/mask/nekoro_deka.png
+000000007742f6f430a9aa4c = textures/eq/mask/nenkoro_deka.png
+000000005f9157a12b14ae1e = textures/eq/mask/nenkorori_deka.png
+0000000090875fbb38a4985d = textures/eq/mask/nekororinyo_deka.png
+000000005b671b2b64b9fc91 = textures/eq/mask/kakin.png
+000000001e378593aae62fbc = textures/eq/mask/kakikoki.png
+00000000db1aea9c80cfb757 = textures/eq/mask/kakkinko.png
+00000000812b4b6931f7c857 = textures/eq/mask/kakkokingu.png
+00000000295edac8956d0ff2 = textures/eq/mask/kakin_deka.png
+000000005a78c5e2da635c36 = textures/eq/mask/kakikoki_deka.png
+00000000e1c2c3a31ae5fad6 = textures/eq/mask/kakkinko_deka.png
+000000008596dac84fd1597a = textures/eq/mask/kakkokingu_deka.png
+00000000e19733f944926c00 = textures/eq/mask/hirara.png
+000000007e56fc7cbf1507d9 = textures/eq/mask/hirarin.png
+000000006652b02ac1e53728 = textures/eq/mask/hiraratto.png
+000000009fe1361f2cdb6eef = textures/eq/mask/hirarinmaru.png
+00000000bb184d767b4a5e09 = textures/eq/mask/hirara_deka.png
+00000000a24783b0af0c520a = textures/eq/mask/hirarin_deka.png
+000000006bbf658343122c7c = textures/eq/mask/hiraratto_deka.png
+000000001f048e5219f2ca5e = textures/eq/mask/hirarinmaru_deka.png
+0000000091d978ccf8c2c536 = textures/eq/mask/biyoyo.png
+00000000416721d1f21aa4c5 = textures/eq/mask/biyoyon.png
+00000000af6d845c6826c9a4 = textures/eq/mask/byororon.png
+00000000508590d137ba2ca4 = textures/eq/mask/babyobyon.png
+00000000340d54c174718c7f = textures/eq/mask/biyoyo_deka.png
+00000000aa7a91094127a376 = textures/eq/mask/biyoyon_deka.png
+00000000b2d4b7a16859072a = textures/eq/mask/byororon_deka.png
+00000000effbe2f3aa2a67e9 = textures/eq/mask/babyobyon_deka.png
+00000000102157c577ff75f2 = textures/eq/mask/doshishi.png
+0000000012044c0928d49f0d = textures/eq/mask/dosshiri.png
+00000000181341ee2eb9aad3 = textures/eq/mask/zundoshiri.png
+0000000085d89622e1057be5 = textures/eq/mask/doshirittan.png
+0000000057bdd031988ae81a = textures/eq/mask/doshishi_deka.png
+0000000068d98e3d959a71a3 = textures/eq/mask/dosshiri_deka.png
+00000000d052a08b808d4f6e = textures/eq/mask/zundoshiri_deka.png
+00000000ed49b2aeb296dac5 = textures/eq/mask/doshirittan_deka.png
+000000009ac1df641855d9b0 = textures/eq/mask/shitoto.png
+0000000043b9cd715737d5e8 = textures/eq/mask/shitton.png
+00000000f7b919a5d01b3eaf = textures/eq/mask/shittoriyo.png
+000000002930921ac64250c4 = textures/eq/mask/shittorrine.png
+00000000b07cb9948afc05b6 = textures/eq/mask/shitoto_deka.png
+000000000d86eadbbbe35cfe = textures/eq/mask/shitton_deka.png
+000000001eb84d58c6d0059b = textures/eq/mask/shittoriyo_deka.png
+000000007ee530bbf3d435fd = textures/eq/mask/shittorrine_deka.png
+0000000061cac60208018f88 = textures/eq/mask/meranya.png
+000000007209520f28d61f19 = textures/eq/mask/nameranya.png
+0000000043325f451102cc27 = textures/eq/mask/dameranya.png
+000000009278d820f38e4d83 = textures/eq/mask/dameranyan.png
+000000005052dd98ed7315d9 = textures/eq/mask/meranya_deka.png
+000000006cc0789f4478f8ea = textures/eq/mask/nameranya_deka.png
+00000000a49d534511ca82fe = textures/eq/mask/dameranya_deka.png
+000000006adb7fcddc0ff652 = textures/eq/mask/dameranyan_deka.png
+000000003f3d970ee012a8c0 = textures/eq/mask/popoka.png
+0000000065956308f252e27e = textures/eq/mask/pokapoka.png
+0000000037141ec14ce608a9 = textures/eq/mask/popopokka.png
+000000007b4421c4b2f6146a = textures/eq/mask/poppkaana.png
+00000000a7ea10c0ae14d7e2 = textures/eq/mask/popoka_deka.png
+000000009d9a3016cd1fc8ed = textures/eq/mask/pokapoka_deka.png
+000000000bfda3b1840b8516 = textures/eq/mask/popopokka_deka.png
+0000000064fdab94e9eb76a2 = textures/eq/mask/poppkaana_deka.png
+000000000b5dd8249a5b833e = textures/eq/mask/nonburu.png
+00000000fc74e715042c40b9 = textures/eq/mask/nonbururu.png
+00000000d3a94ff1639f67fa = textures/eq/mask/nonnooburu.png
+000000001767f23a27feb3b0 = textures/eq/mask/nonburussa.png
+000000003ffe7ab6473bc2c1 = textures/eq/mask/nonburu_deka.png
+000000009a84ca74f1ab5b48 = textures/eq/mask/nonbururu_deka.png
+000000000bd34a1474d3bb48 = textures/eq/mask/nonnooburu_deka.png
+00000000c7c9baab0b473fab = textures/eq/mask/nonburussa_deka.png
+00000000327e375e58570196 = textures/eq/mask/babiri.png
+00000000d158c36099073636 = textures/eq/mask/babirira.png
+00000000eaee5cf28b49de40 = textures/eq/mask/babiriino.png
+0000000044567ae5bafc9a47 = textures/eq/mask/babinonnon.png
+000000004b475f4eef183bb8 = textures/eq/mask/babiri_deka.png
+000000004b8491b85239b1cf = textures/eq/mask/babirira_deka.png
+00000000a474718b79734515 = textures/eq/mask/babiriino_deka.png
+000000006ad94f5799c67dcb = textures/eq/mask/babinonnon_deka.png
+000000004941dca600dedf8f = textures/eq/mask/jirin.png
+00000000bae129bbdaa5fc75 = textures/eq/mask/jiririn.png
+0000000001257eaa5a48f4d2 = textures/eq/mask/jinjirin.png
+00000000a4ca60bf6a72583f = textures/eq/mask/jiririntan.png
+00000000f99cb1ca338e7116 = textures/eq/mask/jirin_deka.png
+0000000064a96b505dd94d25 = textures/eq/mask/jiririn_deka.png
+0000000014659fde2aa210f4 = textures/eq/mask/jinjirin_deka.png
+000000006116573dd43f7c7f = textures/eq/mask/jiririntan_deka.png
+00000000d4c6cc9b84e8583e = textures/eq/mask/zubaba.png
+0000000028d9ffa3dbb17a5f = textures/eq/mask/zubizuba.png
+0000000029f2080ac20e1227 = textures/eq/mask/zunzunbiba.png
+00000000537f6dbbfafd18fe = textures/eq/mask/zubizubabaya.png
+0000000073c8a245947b06fc = textures/eq/mask/zubaba_deka.png
+000000003ce7407abfc8bc57 = textures/eq/mask/zubizuba_deka.png
+00000000d73254c1ec2f667c = textures/eq/mask/zunzunbiba_deka.png
+00000000c573dca2f63f2c0d = textures/eq/mask/zubizubabaya_deka.png
+00000000e49151f3c5590327 = textures/eq/mask/kachiko.png
+0000000096cfe4f40e872d34 = textures/eq/mask/kachikochi_unique.png
+00000000faab7d33f0a43133 = textures/eq/mask/kacchinko.png
+0000000000f14d5da7aed248 = textures/eq/mask/kachinkocchi.png
+000000001a563548f2cca9cb = textures/eq/mask/kachiko_deka.png
+000000005014e9ef667b5746 = textures/eq/mask/kachikochi_unique_deka.png
+00000000856dd107982adde7 = textures/eq/mask/kacchinko_deka.png
+00000000875fb8eadf22dce8 = textures/eq/mask/kachinkocchi_deka.png
+00000000d56621fc5d2a51ab = textures/eq/mask/myuu.png
+000000004d812be94f53e1c6 = textures/eq/mask/myuuto.png
+0000000002bde5d66659bb78 = textures/eq/mask/myuutan.png
+000000002670cc2d4d71891e = textures/eq/mask/myuutaron.png
+00000000166ed7e3df65e69c = textures/eq/mask/myuu_deka.png
+000000005f5783bc2838d326 = textures/eq/mask/myuuto_deka.png
+000000007463aedd6169248e = textures/eq/mask/myuutan_deka.png
+00000000f2296b30b0db3e15 = textures/eq/mask/myuutaron_deka.png
+00000000ae3c26adaeed88da = textures/eq/mask/dogyuun.png
+000000000307edb0f7148885 = textures/eq/mask/dongyugyu.png
+000000008aa78bb6dfe776b4 = textures/eq/mask/dodongyuu.png
+00000000abdfacd4308498ed = textures/eq/mask/zuddongyu.png
+00000000d3671b0e06756577 = textures/eq/mask/dogyuun_deka.png
+00000000aaa306f7c69ddd31 = textures/eq/mask/dongyugyu_deka.png
+000000009e2a752927763650 = textures/eq/mask/dodongyuu_deka.png
+00000000438ea4191a16de06 = textures/eq/mask/zuddongyu_deka.png
+00000000c34ccdf6dee956fc = textures/eq/mask/subasara.png
+000000004ab1584175e36ab1 = textures/eq/mask/rabasara.png
+000000001e39b94b550da549 = textures/eq/mask/raparassa.png
+00000000b7ff2e90f36d0a93 = textures/eq/mask/rapasaraana.png
+00000000c79000e173adbec2 = textures/eq/mask/subasara_deka.png
+00000000e37283680d885170 = textures/eq/mask/rabasara_deka.png
+00000000ed8625f782c06812 = textures/eq/mask/raparassa_deka.png
+00000000adf843daaa252c70 = textures/eq/mask/rapasaraana_deka.png
+00000000e548ec022aaf863f = textures/eq/mask/karmen_mask_1.png
+00000000432636f5d11c2814 = textures/eq/mask/karmen_mask_2.png
+000000003aaefa1a851de314 = textures/eq/mask/karmen_mask_3.png
+00000000aed3133f155e4ba4 = textures/eq/mask/karmen_mask_4.png
+000000007061b6ae8e69fd24 = textures/eq/mask/karmen_mask_5.png
+000000005298607e11b2ec01 = textures/eq/mask/dark_mask.png
 
-#Helms#
-00000000c54509bb7e3ccae4 = textures/eq/helm/wood_helm.png
-000000009dd88c170abd74bd = textures/eq/helm/iron_helm.png
-00000000dc701a63f01c21d9 = textures/eq/helm/steel_helm.png
-000000006470c04f79a318a3 = textures/eq/helm/wind_helm.png
-00000000c8e4f10252a5210e = textures/eq/helm/strength_helm.png
-#000000005c59840f423cc464 = textures/eq/helm/ancient_helm.png
-#000000009904d3b6e1399737 = textures/eq/helm/giant_helm.png
-0000000025ef11191c28efe4 = textures/eq/helm/divine_helm.png
-#000000002825aacd0c8a30c3 = textures/eq/helm/bunny_helm.png
-00000000001640d5b0a44767 = textures/eq/helm/gongs_helm.png
-#0000000096df35a94200b3d6 = textures/eq/helm/fire_helm.png
-#00000000cd529f023463ab39 = textures/eq/helm/thunder_helm.png
-#00000000d202849b73dc3c6e = textures/eq/helm/snow_helm.png
-#000000009cca6d3b4a465ac2 = textures/eq/helm/lightning_helm.png
-#000000001b4f8ae9d99da61d = textures/eq/helm/sun_helm.png
-#00000000bb90f773ea5df6ce = textures/eq/helm/dragon_helm.png
-000000006843c9d6b75bc153 = textures/eq/helm/wing_helm.png
-00000000156ffc0c3edd2ec3 = textures/eq/helm/chef_helm.png
-#00000000a166e8e1c917d20b = textures/eq/helm/jeweled_helm.png
-000000006695eb4aa8b00605 = textures/eq/helm/samurai_helm.png
-000000004a4fbd2bf0093183 = textures/eq/helm/heaven_helm.png
-0000000045390b80f810fe0c = textures/eq/helm/demon_helm.png
-#00000000dcdc6162c3a644d7 = textures/eq/helm/friendship_helm.png
-00000000ca131eb1c96c01bb = textures/eq/helm/great_mighty_helmet.png
-#00000000a8561b01aba16d52 = textures/eq/helm/lordly_hairpiece.png
-000000000c43f0dbad6c737e = textures/eq/helm/stage_1_deka.png
-0000000084b22e81ec2bd950 = textures/eq/helm/stage_2_deka.png
-00000000f10682fb496cdd9c = textures/eq/helm/stage_3_deka.png
-0000000066844a10f639ae07 = textures/eq/helm/stage_1_mega.png
-00000000e0da94bd8559ead5 = textures/eq/helm/stage_2_mega.png
-00000000244d0afaeae4344d = textures/eq/helm/stage_3_mega.png
-00000000fe3ff8cfea1b0600 = textures/eq/helm/stage_1_maho.png
-00000000a0b2456455e44352 = textures/eq/helm/stage_2_maho.png
-000000009c2d7475379f98c4 = textures/eq/helm/stage_3_maho.png
-#mega1
-#mega2
-#mega3
-00000000437f5e9b4f34884b = textures/eq/helm/dark_helmet.png
+# Helms
+# HASH_TO_UPDATE_00000000c54509bb7e3ccae4 = textures/eq/helm/wood_helm.png
+000000009dd88c178ad191ab = textures/eq/helm/iron_helm.png
+00000000dc701a63d6ff1e44 = textures/eq/helm/steel_helm.png
+000000006470c04fd7964119 = textures/eq/helm/wind_helm.png
+00000000c8e4f102f7d804d5 = textures/eq/helm/strength_helm.png
+# 000000005c59840f5908a93a = textures/eq/helm/ancient_helm.png
+# 000000009904d3b62a76bb4a = textures/eq/helm/giant_helm.png
+0000000025ef11193f7f2d35 = textures/eq/helm/divine_helm.png
+# HASH_TO_UPDATE_000000002825aacd0c8a30c3 = textures/eq/helm/bunny_helm.png
+00000000001640d5ab6b8633 = textures/eq/helm/gongs_helm.png
+# 0000000096df35a9d10a6f31 = textures/eq/helm/fire_helm.png
+# 00000000cd529f022cdb56bb = textures/eq/helm/thunder_helm.png
+# 00000000d202849b41d9e5a2 = textures/eq/helm/snow_helm.png
+# 000000009cca6d3b900d7d22 = textures/eq/helm/lightning_helm.png
+# 000000001b4f8ae9033cbb2f = textures/eq/helm/sun_helm.png
+# 00000000bb90f77324f9b747 = textures/eq/helm/dragon_helm.png
+000000006843c9d65e208d83 = textures/eq/helm/wing_helm.png
+00000000156ffc0c2400442f = textures/eq/helm/chef_helm.png
+# 00000000a166e8e1d066d8b9 = textures/eq/helm/jeweled_helm.png
+000000006695eb4af27ae849 = textures/eq/helm/samurai_helm.png
+000000004a4fbd2bdced6715 = textures/eq/helm/heaven_helm.png
+0000000045390b8092959d07 = textures/eq/helm/demon_helm.png
+# 00000000dcdc6162cde12804 = textures/eq/helm/friendship_helm.png
+00000000ca131eb167b6301d = textures/eq/helm/great_mighty_helmet.png
+# 00000000a8561b0115b11a84 = textures/eq/helm/lordly_hairpiece.png
+000000000c43f0db5ac3c763 = textures/eq/helm/stage_1_deka.png
+0000000084b22e81ccdf8cfe = textures/eq/helm/stage_2_deka.png
+00000000f10682fbc701ccaa = textures/eq/helm/stage_3_deka.png
+0000000066844a1008b65e69 = textures/eq/helm/stage_1_mega.png
+# HASH_TO_UPDATE_00000000e0da94bd8559ead5 = textures/eq/helm/stage_2_mega.png
+# HASH_TO_UPDATE_00000000244d0afaeae4344d = textures/eq/helm/stage_3_mega.png
+00000000fe3ff8cff83d60c8 = textures/eq/helm/stage_1_maho.png
+00000000a0b2456497f5b7d0 = textures/eq/helm/stage_2_maho.png
+000000009c2d74759c0c363e = textures/eq/helm/stage_3_maho.png
+# mega1
+# mega2
+# mega3
+00000000437f5e9bfab12914 = textures/eq/helm/dark_helmet.png
 
-#Rarepons#
-#Rabbit
-000000001a8338272be320b6 = textures/eq/rarepon/pyopyo.png
-00000000fa5ef7e64becfe3a = textures/eq/rarepon/pyokora.png
-00000000a5924607c86a9259 = textures/eq/rarepon/pyokoran.png
-0000000085b6ce9ce8abab25 = textures/eq/rarepon/pyopyo_deka.png
-000000006929101161d68715 = textures/eq/rarepon/pyokora_deka.png
-000000007624e94012e57679 = textures/eq/rarepon/pyokoran_deka.png
-#Frog
-000000006c4b988fdfd6364c = textures/eq/rarepon/nyontama.png
-000000002a92d175b7f579e6 = textures/eq/rarepon/gekoroth.png
-00000000a9a2dafd6210991a = textures/eq/rarepon/gekoronpa.png
-0000000046e83514b5ebab32 = textures/eq/rarepon/nyontama_deka.png
-00000000dd4a1a82c93cd222 = textures/eq/rarepon/gekoroth_deka.png
-000000005a3dbebbb9eeb82f = textures/eq/rarepon/gekoronpa_deka.png
-#Sheep
-000000007cb9f444961330bb = textures/eq/rarepon/mofo.png
-00000000d8d39b8f9edfc102 = textures/eq/rarepon/moforu.png
-000000009fdf420b21794a71 = textures/eq/rarepon/moforumu.png
-00000000efe1ca4aeacce0b4 = textures/eq/rarepon/mofo_deka.png
-000000007f59164859b571ee = textures/eq/rarepon/moforu_deka.png
-000000000aa05ec131506071 = textures/eq/rarepon/moforumu_deka.png
-#Porcupine
-000000004a56142f32f34915 = textures/eq/rarepon/chiku.png
-00000000a8ba1fcbb8a75ef1 = textures/eq/rarepon/chikkuri.png
-000000006f68046e90b3b84f = textures/eq/rarepon/chikurinchi.png
-00000000f88744168ba292ba = textures/eq/rarepon/chiku_deka.png
-00000000edf75ab7225b3e2e = textures/eq/rarepon/chikkuri_deka.png
-00000000e810417069a09e16 = textures/eq/rarepon/chikurinchi_deka.png
-#Bovine
-0000000027cb7a35c6a18dcd = textures/eq/rarepon/mogyu.png
-00000000bb8542d985c50c6c = textures/eq/rarepon/mogyuun.png
-00000000271cb0f53f011368 = textures/eq/rarepon/mogyugyu.png
-000000003a5c8bd485b19201 = textures/eq/rarepon/mogyu_deka.png
-00000000568f1f6a29ab22a0 = textures/eq/rarepon/mogyuun_deka.png
-0000000092fd659d6fc59d94 = textures/eq/rarepon/mogyugyu_deka.png
-#Bird
-00000000a76addecc7b12678 = textures/eq/rarepon/sabara.png
-000000003ef852c10c9899e1 = textures/eq/rarepon/baasara.png
-0000000023eaf06bd1e8dce8 = textures/eq/rarepon/babassa.png
-00000000f9ee3e3776528a41 = textures/eq/rarepon/sabara_deka.png
-00000000c881fe5977fc452b = textures/eq/rarepon/baasara_deka.png
-00000000289c7ae5de4d4de1 = textures/eq/rarepon/babassa_deka.png
-#Pig
-00000000c45e425d28159b8c = textures/eq/rarepon/buhyokko.png
-000000001f4cdc21c50db406 = textures/eq/rarepon/buhyonku.png
-000000005fcae424c69d8143 = textures/eq/rarepon/puuhyonku.png
-000000001675e7ea4fa48165 = textures/eq/rarepon/buhyokko_deka.png
-00000000ce0dca385f954494 = textures/eq/rarepon/buhyonku_deka.png
-00000000d5882d26b6b63c52 = textures/eq/rarepon/puuhyonku_deka.png
-#Cat
-000000005e0dde57a954a035 = textures/eq/rarepon/fumya.png
-000000004bba070a6fad9f58 = textures/eq/rarepon/fumyaaru.png
-0000000024c286cc5fea472c = textures/eq/rarepon/funmyaga.png
-00000000588ff34bec94d329 = textures/eq/rarepon/fumya_deka.png
-00000000bc0bb12ce84bd81d = textures/eq/rarepon/fumyaaru_deka.png
-00000000fe1a724677aa5f6d = textures/eq/rarepon/funmyaga_deka.png
-#Dog
-000000006455f5d5192dc1b2 = textures/eq/rarepon/wanda.png
-000000006a2b93cfbecef7f3 = textures/eq/rarepon/wandaba.png
-0000000082833472eb0feab7 = textures/eq/rarepon/wandabata.png
-000000001e7fa6e6fcb47703 = textures/eq/rarepon/wanda_deka.png
-0000000040a46ed6be7bb133 = textures/eq/rarepon/wandaba_deka.png
-0000000074ca19e3d50d7da9 = textures/eq/rarepon/wandabata_deka.png
-#Tree
-0000000079c432f51f0f08f2 = textures/eq/rarepon/menyokki.png
-000000000f3d6aeedd8e023d = textures/eq/rarepon/kisuk.png
-00000000778b4e8d81511902 = textures/eq/rarepon/moriussoo.png
-00000000e639d8274c369010 = textures/eq/rarepon/menyokki_deka.png
-000000000df47f37cb8aa450 = textures/eq/rarepon/kisuk_deka.png
-0000000056a60bd629398586 = textures/eq/rarepon/moriussoo_deka.png
-#Fish
-00000000dfb038e9517a0eef = textures/eq/rarepon/chigyobi.png
-0000000098d03a792d2a4900 = textures/eq/rarepon/gyopicchi.png
-000000008ff487c52cf0b096 = textures/eq/rarepon/gyogyoppa.png
-00000000b857e7935cd7e771 = textures/eq/rarepon/chigyobi_deka.png
-000000007b7defa93763d765 = textures/eq/rarepon/gyopicchi_deka.png
-00000000537835b3f89967d4 = textures/eq/rarepon/gyogyoppa_deka.png
-#Monkey
-000000004d58df85d785b07d = textures/eq/rarepon/uhoho.png
-000000002f4a103adadce569 = textures/eq/rarepon/uuhoho.png
-000000002dd6a7497d9e1f7e = textures/eq/rarepon/uhokkya.png
-000000004d974e488247416b = textures/eq/rarepon/uhoho_deka.png
-0000000082e797db9ea9c08c = textures/eq/rarepon/uuhoho_deka.png
-000000004732d3cee821cd6a = textures/eq/rarepon/uhokkya_deka.png
-#Mushroom
-000000008baf1eaa8df32c7b = textures/eq/rarepon/mashu.png
-000000005e5bf690df5c7f0c = textures/eq/rarepon/mashuro.png
-00000000e1424098b321a5cb = textures/eq/rarepon/mashuriro.png
-00000000b1ef2a89fda4f130 = textures/eq/rarepon/mashu_deka.png
-000000001d761daf29bd0ff7 = textures/eq/rarepon/mashuro_deka.png
-00000000f813dd13293fadee = textures/eq/rarepon/mashuriro_deka.png
-#Penguin
-000000004cf4de14b5ca4fb4 = textures/eq/rarepon/koppen.png
-00000000bb1d326626cf6c63 = textures/eq/rarepon/suppen.png
-00000000b2779f865f8fd691 = textures/eq/rarepon/supengu.png
-00000000522d77d1dcf674f0 = textures/eq/rarepon/koppen_deka.png
-000000000643afe2e428aefb = textures/eq/rarepon/suppen_deka.png
-00000000776add83ab9b37ed = textures/eq/rarepon/supengu_deka.png
-#Deer
-000000004e389abd0a0ee20c = textures/eq/rarepon/kanokko.png
-00000000d10e151a1af8b459 = textures/eq/rarepon/kanokyon.png
-000000003c71007d56f32358 = textures/eq/rarepon/kanodia.png
-00000000ca1566ce5da6ab0f = textures/eq/rarepon/kanokko_deka.png
-00000000c8931d794694c944 = textures/eq/rarepon/kanokyon_deka.png
-00000000ac13a8c397d091b9 = textures/eq/rarepon/kanodia_deka.png
-#Dragon
-00000000139b190f5e9cbc4f = textures/eq/rarepon/gyaba.png
-00000000ff7ba17b20f6b225 = textures/eq/rarepon/gyabaan.png
-00000000fcc24e6fc5b61d56 = textures/eq/rarepon/wagyanba.png
-00000000c221ff7f9df3d194 = textures/eq/rarepon/gyaba_deka.png
-000000007e0d2752b7c7ffab = textures/eq/rarepon/gyabaan_deka.png
-0000000069cd152b3be3dce4 = textures/eq/rarepon/wagyanba_deka.png
+# Rarepons
+# Rabbit
+000000001a833827f5ee93f6 = textures/eq/rarepon/pyopyo.png
+00000000fa5ef7e6ba9a9e66 = textures/eq/rarepon/pyokora.png
+00000000a5924607f47d66ed = textures/eq/rarepon/pyokoran.png
+0000000085b6ce9cc84967a8 = textures/eq/rarepon/pyopyo_deka.png
+00000000692910113eb73343 = textures/eq/rarepon/pyokora_deka.png
+000000007624e9408755b267 = textures/eq/rarepon/pyokoran_deka.png
+# Frog
+000000006c4b988f076a0777 = textures/eq/rarepon/nyontama.png
+# HASH_TO_UPDATE_000000002a92d175b7f579e6 = textures/eq/rarepon/gekoroth.png
+00000000a9a2dafd459d1178 = textures/eq/rarepon/gekoronpa.png
+0000000046e8351422c98f66 = textures/eq/rarepon/nyontama_deka.png
+00000000dd4a1a829e14b2c4 = textures/eq/rarepon/gekoroth_deka.png
+000000005a3dbebb32feb196 = textures/eq/rarepon/gekoronpa_deka.png
+# Sheep
+000000007cb9f44485f4b890 = textures/eq/rarepon/mofo.png
+00000000d8d39b8fe3cf3754 = textures/eq/rarepon/moforu.png
+000000009fdf420b9f6f8ef0 = textures/eq/rarepon/moforumu.png
+00000000efe1ca4a8ec4ed49 = textures/eq/rarepon/mofo_deka.png
+000000007f591648a1787756 = textures/eq/rarepon/moforu_deka.png
+000000000aa05ec1494e3c67 = textures/eq/rarepon/moforumu_deka.png
+# Porcupine
+000000004a56142fb3abfe7e = textures/eq/rarepon/chiku.png
+00000000a8ba1fcb99719a2e = textures/eq/rarepon/chikkuri.png
+000000006f68046e32475d19 = textures/eq/rarepon/chikurinchi.png
+00000000f8874416810f7cb1 = textures/eq/rarepon/chiku_deka.png
+00000000edf75ab79bd405eb = textures/eq/rarepon/chikkuri_deka.png
+00000000e8104170a9c9bca2 = textures/eq/rarepon/chikurinchi_deka.png
+# Bovine
+0000000027cb7a3578027254 = textures/eq/rarepon/mogyu.png
+00000000bb8542d977e83872 = textures/eq/rarepon/mogyuun.png
+00000000271cb0f5cb09c50a = textures/eq/rarepon/mogyugyu.png
+000000003a5c8bd4b87d45b7 = textures/eq/rarepon/mogyu_deka.png
+00000000568f1f6a797ab3bf = textures/eq/rarepon/mogyuun_deka.png
+0000000092fd659d79161d0c = textures/eq/rarepon/mogyugyu_deka.png
+# Bird
+00000000a76addecb546641c = textures/eq/rarepon/sabara.png
+000000003ef852c119e0bb0d = textures/eq/rarepon/baasara.png
+0000000023eaf06b3367000c = textures/eq/rarepon/babassa.png
+00000000f9ee3e3768535cb5 = textures/eq/rarepon/sabara_deka.png
+00000000c881fe59817153ee = textures/eq/rarepon/baasara_deka.png
+00000000289c7ae5c12adbfc = textures/eq/rarepon/babassa_deka.png
+# Pig
+00000000c45e425d821f1777 = textures/eq/rarepon/buhyokko.png
+000000001f4cdc210c57e374 = textures/eq/rarepon/buhyonku.png
+000000005fcae424b3a41089 = textures/eq/rarepon/puuhyonku.png
+000000001675e7ea36951277 = textures/eq/rarepon/buhyokko_deka.png
+00000000ce0dca387d625c97 = textures/eq/rarepon/buhyonku_deka.png
+00000000d5882d2664a6777f = textures/eq/rarepon/puuhyonku_deka.png
+# Cat
+000000005e0dde57677497a6 = textures/eq/rarepon/fumya.png
+000000004bba070a05730d87 = textures/eq/rarepon/fumyaaru.png
+0000000024c286cc013a148d = textures/eq/rarepon/funmyaga.png
+00000000588ff34b28cab18c = textures/eq/rarepon/fumya_deka.png
+00000000bc0bb12c943a622b = textures/eq/rarepon/fumyaaru_deka.png
+00000000fe1a72467a123dbc = textures/eq/rarepon/funmyaga_deka.png
+# Dog
+000000006455f5d508b6b57e = textures/eq/rarepon/wanda.png
+000000006a2b93cf3025b879 = textures/eq/rarepon/wandaba.png
+00000000828334727a56ae1f = textures/eq/rarepon/wandabata.png
+000000001e7fa6e63b8ba6d3 = textures/eq/rarepon/wanda_deka.png
+0000000040a46ed63d3464b1 = textures/eq/rarepon/wandaba_deka.png
+0000000074ca19e3049f9a5a = textures/eq/rarepon/wandabata_deka.png
+# Tree
+0000000079c432f5c9f0c304 = textures/eq/rarepon/menyokki.png
+000000000f3d6aee5b6088d7 = textures/eq/rarepon/kisuk.png
+00000000778b4e8ddfddabd9 = textures/eq/rarepon/moriussoo.png
+00000000e639d827293a9cfe = textures/eq/rarepon/menyokki_deka.png
+000000000df47f37b24630a2 = textures/eq/rarepon/kisuk_deka.png
+0000000056a60bd631ce9cf8 = textures/eq/rarepon/moriussoo_deka.png
+# Fish
+00000000dfb038e980488dde = textures/eq/rarepon/chigyobi.png
+0000000098d03a79c8edb0fd = textures/eq/rarepon/gyopicchi.png
+000000008ff487c51afaf70b = textures/eq/rarepon/gyogyoppa.png
+00000000b857e7937716f818 = textures/eq/rarepon/chigyobi_deka.png
+000000007b7defa9d944ac00 = textures/eq/rarepon/gyopicchi_deka.png
+00000000537835b3035aca42 = textures/eq/rarepon/gyogyoppa_deka.png
+# Monkey
+000000004d58df85d97d266f = textures/eq/rarepon/uhoho.png
+000000002f4a103a2b2cdf9f = textures/eq/rarepon/uuhoho.png
+000000002dd6a749c5286e96 = textures/eq/rarepon/uhokkya.png
+000000004d974e4875e55cf7 = textures/eq/rarepon/uhoho_deka.png
+# HASH_TO_UPDATE_0000000082e797db9ea9c08c = textures/eq/rarepon/uuhoho_deka.png
+000000004732d3ce6ba9525b = textures/eq/rarepon/uhokkya_deka.png
+# Mushroom
+000000008baf1eaaebcaebbd = textures/eq/rarepon/mashu.png
+000000005e5bf690d02c7c3b = textures/eq/rarepon/mashuro.png
+00000000e14240989e52ddd2 = textures/eq/rarepon/mashuriro.png
+00000000b1ef2a894bc5e6de = textures/eq/rarepon/mashu_deka.png
+000000001d761daf122dc8a6 = textures/eq/rarepon/mashuro_deka.png
+00000000f813dd134bdc295f = textures/eq/rarepon/mashuriro_deka.png
+# Penguin
+000000004cf4de1402f81742 = textures/eq/rarepon/koppen.png
+00000000bb1d32666bd7fd84 = textures/eq/rarepon/suppen.png
+00000000b2779f86db6d2649 = textures/eq/rarepon/supengu.png
+00000000522d77d1f417b335 = textures/eq/rarepon/koppen_deka.png
+000000000643afe2c670a3c2 = textures/eq/rarepon/suppen_deka.png
+00000000776add83e3391b4b = textures/eq/rarepon/supengu_deka.png
+# Deer
+000000004e389abd5652eb56 = textures/eq/rarepon/kanokko.png
+00000000d10e151a39b58e7c = textures/eq/rarepon/kanokyon.png
+000000003c71007d3bdc95e2 = textures/eq/rarepon/kanodia.png
+00000000ca1566ce0956d171 = textures/eq/rarepon/kanokko_deka.png
+00000000c8931d798b34aa22 = textures/eq/rarepon/kanokyon_deka.png
+00000000ac13a8c3b890425a = textures/eq/rarepon/kanodia_deka.png
+# Dragon
+00000000139b190fce194be4 = textures/eq/rarepon/gyaba.png
+00000000ff7ba17bccfe09d3 = textures/eq/rarepon/gyabaan.png
+00000000fcc24e6f156a99fa = textures/eq/rarepon/wagyanba.png
+00000000c221ff7f39e13d62 = textures/eq/rarepon/gyaba_deka.png
+000000007e0d27528444f890 = textures/eq/rarepon/gyabaan_deka.png
+0000000069cd152b94d75105 = textures/eq/rarepon/wagyanba_deka.png
 
-#Spears#
-0000000027304a7e006e491e = textures/eq/spear/wood_spear.png
-000000001569226f76fc24aa = textures/eq/spear/iron_spear.png
-000000007330a22d692e76c1 = textures/eq/spear/steel_spear.png
-#00000000d60abda2d7a336ec = textures/eq/spear/fire_spear.png
-000000002566e7f18926b39f = textures/eq/spear/dokaknels_fang.png
-00000000c2e3eb5cce38160a = textures/eq/spear/ancient_spear.png
-#giant spear is placeholder
-00000000c32d9e0dfbc731ad = textures/eq/spear/giant_spear.png
-000000002a2eaad56f6ecc43 = textures/eq/spear/divine_spear.png
-#0000000056d3dc5ec6914075 = textures/eq/spear/protection_spear.png
-#000000007c69cf361e43e9df = textures/eq/spear/ice_spear.png
-#00000000457c7f6a6620fb9a = textures/eq/spear/dream_spear.png
-#000000009d1ad40ad8fcda77 = textures/eq/spear/thunder_spear.png
-#0000000093b7ae53627d9d42 = textures/eq/spear/great_fire_spear.png
-#000000001a5ed37d8734b14d = textures/eq/spear/great_ice_spear.png
-#00000000eafd60f8dec17b8e = textures/eq/spear/great_thunder_spear.png
-#00000000226a513af785aadb = textures/eq/spear/heaven_spear.png
-000000003d25191fed7c94bf = textures/eq/spear/demon_spear.png
-#00000000bc76ea2232148cc8 = textures/eq/spear/friendship_spear.png
+# Spears
+0000000027304a7e1cf8b7fa = textures/eq/spear/wood_spear.png
+000000001569226fff4dd1fa = textures/eq/spear/iron_spear.png
+000000007330a22d71acb75b = textures/eq/spear/steel_spear.png
+# 00000000d60abda2498d5953 = textures/eq/spear/fire_spear.png
+000000002566e7f1c424de14 = textures/eq/spear/dokaknels_fang.png
+00000000c2e3eb5c9f363179 = textures/eq/spear/ancient_spear.png
+# giant spear is placeholder
+00000000c32d9e0d75a5f1ed = textures/eq/spear/giant_spear.png
+000000002a2eaad5d3caacad = textures/eq/spear/divine_spear.png
+# 0000000056d3dc5e383f2bc1 = textures/eq/spear/protection_spear.png
+# 000000007c69cf3646e21d9a = textures/eq/spear/ice_spear.png
+# 00000000457c7f6a53cc4214 = textures/eq/spear/dream_spear.png
+# 000000009d1ad40ac058edc2 = textures/eq/spear/thunder_spear.png
+# 0000000093b7ae5319a93f90 = textures/eq/spear/great_fire_spear.png
+# 000000001a5ed37d23bf37d7 = textures/eq/spear/great_ice_spear.png
+# 00000000eafd60f82af63210 = textures/eq/spear/great_thunder_spear.png
+# 00000000226a513a99819fdd = textures/eq/spear/heaven_spear.png
+000000003d25191f5cf396d6 = textures/eq/spear/demon_spear.png
+# 00000000bc76ea22daaef961 = textures/eq/spear/friendship_spear.png
 
-#Swords#
-000000004f07ecf8ad8c2d8e = textures/eq/sword/tin_axe.png
-00000000c0397a4748c96990 = textures/eq/sword/iron_sword.png
-000000009892998046fd9b24 = textures/eq/sword/steel_axe.png
-00000000e2f33e6a62509910 = textures/eq/sword/sleepy_sword.png
-00000000f33696b9d9a57719 = textures/eq/sword/ancient_axe.png
-0000000071a4d6c3cf791c59 = textures/eq/sword/butcher.png
-0000000068e49a60fc228ca5 = textures/eq/sword/divine_axe.png
-00000000542447fa4d614a08 = textures/eq/sword/ice_sword.png
-00000000d3e802408e5cb5b2 = textures/eq/sword/thunder_sword.png
-00000000d0b4449fe5a6d097 = textures/eq/sword/magic_axe_labrys.png
+# Swords
+000000004f07ecf8ca64cdf4 = textures/eq/sword/tin_axe.png
+00000000c0397a475cc56513 = textures/eq/sword/iron_sword.png
+000000009892998052605f03 = textures/eq/sword/steel_axe.png
+00000000e2f33e6a71e9b33d = textures/eq/sword/sleepy_sword.png
+00000000f33696b91dcc4073 = textures/eq/sword/ancient_axe.png
+0000000071a4d6c3b740e082 = textures/eq/sword/butcher.png
+0000000068e49a6089e9e652 = textures/eq/sword/divine_axe.png
+00000000542447fac6ee1acc = textures/eq/sword/ice_sword.png
+00000000d3e8024014acd5e3 = textures/eq/sword/thunder_sword.png
+00000000d0b4449f32d61eaa = textures/eq/sword/magic_axe_labrys.png
 
-#Shields#
-000000001ebd2de1768738b2 = textures/eq/shield/wood_shield.png
-000000004d785367c902d9f6 = textures/eq/shield/iron_shield.png
-000000006c0cb281b8f01efd = textures/eq/shield/steel_shield.png
-#ice shield here :)
-000000008fb04bc3bb8b80f9 = textures/eq/shield/ultra_heavy_shield.png
-00000000ca8f75c78c526d34 = textures/eq/shield/ancient_shield.png
-0000000077655588267ac4a3 = textures/eq/shield/thunder_shield.png
-000000004bbe0cb77c9b8c91 = textures/eq/shield/demon_shield.png
+# Shields
+000000001ebd2de1ab10c0b8 = textures/eq/shield/wood_shield.png
+000000004d785367ffce5132 = textures/eq/shield/iron_shield.png
+000000006c0cb2818b66cf61 = textures/eq/shield/steel_shield.png
+# ice shield here :)
+000000008fb04bc36513f8e5 = textures/eq/shield/ultra_heavy_shield.png
+00000000ca8f75c7a50f44b7 = textures/eq/shield/ancient_shield.png
+0000000077655588d562b475 = textures/eq/shield/thunder_shield.png
+000000004bbe0cb73b8387da = textures/eq/shield/demon_shield.png
 
-#Bows#
-00000000dec575bec53d7569 = textures/eq/bow/wood_bow.png
-#WIP i just really like the heaven bows design ok
-000000002a73c79628b929cb = textures/eq/bow/heaven_bow.png
-#Arrows#
-000000001fb682f718b4e6e0 = textures/eq/bow/arrow.png
-00000000ff85f940a8acae18 = textures/eq/bow/glowing_arrow.png
-00000000588421338220179f = textures/eq/bow/broken_arrow.png
+# Bows
+00000000dec575bea488b8d3 = textures/eq/bow/wood_bow.png
+# WIP i just really like the heaven bows design ok
+000000002a73c796d53b1b1e = textures/eq/bow/heaven_bow.png
+# Arrows
+000000001fb682f70dc10043 = textures/eq/bow/arrow.png
+00000000ff85f9407a526760 = textures/eq/bow/glowing_arrow.png
+0000000058842133cf5efc86 = textures/eq/bow/broken_arrow.png
 
-#Halberds#
-000000006818e2440fdb0777 = textures/eq/halberd/wood_halberd.png
-0000000068d9cbd9ac6ea982 = textures/eq/halberd/iron_halberd.png
+# Halberds
+000000006818e244b882a209 = textures/eq/halberd/wood_halberd.png
+0000000068d9cbd936b556ba = textures/eq/halberd/iron_halberd.png
 
-#Horses#
-000000008ac0d0fb1d00a99b = textures/eq/horse/horse.png
-000000004f0281b4a768f7e1 = textures/eq/horse/tough_horse.png
-000000009b19574075774879 = textures/eq/horse/strong_horse.png
-00000000d78d60497d33dd17 = textures/eq/horse/blue_horse.png
-0000000043496e5fb8652dc7 = textures/eq/horse/yellow_horse.png
-00000000447a3751bd31cf1c = textures/eq/horse/ice_horse.png
-000000007377f77ccfee78b9 = textures/eq/horse/dragon_horse.png
-0000000011d140b73568d025 = textures/eq/horse/heaven_horse.png
+# Horses
+000000008ac0d0fb6e697b7c = textures/eq/horse/horse.png
+000000004f0281b42db67cda = textures/eq/horse/tough_horse.png
+000000009b195740a1498f7a = textures/eq/horse/strong_horse.png
+00000000d78d604987834b30 = textures/eq/horse/blue_horse.png
+0000000043496e5f62d8f89e = textures/eq/horse/yellow_horse.png
+00000000447a3751713c9dd1 = textures/eq/horse/ice_horse.png
+000000007377f77c723463f8 = textures/eq/horse/dragon_horse.png
+0000000011d140b7a2a18cc1 = textures/eq/horse/heaven_horse.png
 
-#Clubs#
-00000000e272d592bba3a6d7 = textures/eq/club/iron_hammer.png
-00000000b5622bf733f688b4 = textures/eq/club/steel_mace.png
-00000000b20bde128b1f147f = textures/eq/club/dreamweaver.png
-00000000dde55fe00b2bb460 = textures/eq/club/giant_club.png
-#the following texture is a placeholder!
-00000000a5dc7108d2c7fba9 = textures/eq/club/thor.png
+# Clubs
+00000000e272d5922c132a39 = textures/eq/club/iron_hammer.png
+00000000b5622bf7d18eef33 = textures/eq/club/steel_mace.png
+00000000b20bde129caa341d = textures/eq/club/dreamweaver.png
+00000000dde55fe0cbb15afb = textures/eq/club/giant_club.png
+# the following texture is a placeholder!
+00000000a5dc7108b7909f22 = textures/eq/club/thor.png
 
-#Shoulders#
-00000000257d57c57bf6d639 = textures/eq/shoulder/leather_shoulder.png
+# Shoulders
+00000000257d57c58e29985d = textures/eq/shoulder/leather_shoulder.png
 
-#Horns#
-0000000081ffcdb76b24a586 = textures/eq/horn/wood_horn.png
-00000000fef580d1f1f8b255 = textures/eq/horn/iron_horn.png
-00000000ae12f64738826038 = textures/eq/horn/steel_horn.png
-00000000782bc703ec036983 = textures/eq/horn/gaeen_horn.png
-0000000049b1358862733fe2 = textures/eq/horn/cioking_horn.png
-0000000074616dbd80641b6f = textures/eq/horn/shookle_horn.png
-00000000a70bbc442305461d = textures/eq/horn/ancient_horn.png
-0000000071836922dbf98a43 = textures/eq/horn/divine_horn.png
-00000000fe2a0711624662c1 = textures/eq/horn/fire_horn.png
-00000000e821c7932d6720cc = textures/eq/horn/ice_horn.png
-00000000c77da7ca3ba2b275 = textures/eq/horn/thunder_horn.png
-#0000000094f4438b6510f9f5 = textures/eq/horn/great_fire_horn.png
-#000000007f939b25bce71939 = textures/eq/horn/great_ice_horn.png
-#000000006bef6dcb6dc8a779 = textures/eq/horn/great_thunder_horn.png
-00000000c2600bcff485deaa = textures/eq/horn/heaven_horn.png
-000000007dac2b90fbabf6c3 = textures/eq/horn/demon_horn.png
-000000005d5e938b9f6df3d6 = textures/eq/horn/friendship_horn.png
+# Horns
+0000000081ffcdb747fce055 = textures/eq/horn/wood_horn.png
+00000000fef580d1b8e959a5 = textures/eq/horn/iron_horn.png
+00000000ae12f6470f0505d9 = textures/eq/horn/steel_horn.png
+00000000782bc703e7ecbc4e = textures/eq/horn/gaeen_horn.png
+0000000049b135880c23abd4 = textures/eq/horn/cioking_horn.png
+0000000074616dbd12c68d4b = textures/eq/horn/shookle_horn.png
+00000000a70bbc447d19efd3 = textures/eq/horn/ancient_horn.png
+000000007183692229b5e4aa = textures/eq/horn/divine_horn.png
+00000000fe2a0711892671cb = textures/eq/horn/fire_horn.png
+00000000e821c793908cf086 = textures/eq/horn/ice_horn.png
+00000000c77da7cac8a51951 = textures/eq/horn/thunder_horn.png
+# 0000000094f4438b015e57ef = textures/eq/horn/great_fire_horn.png
+# 000000007f939b25125787cc = textures/eq/horn/great_ice_horn.png
+# 000000006bef6dcb45859304 = textures/eq/horn/great_thunder_horn.png
+00000000c2600bcf9784463a = textures/eq/horn/heaven_horn.png
+000000007dac2b902a0a0f48 = textures/eq/horn/demon_horn.png
+000000005d5e938b344f3f71 = textures/eq/horn/friendship_horn.png
 
-#Capes#
-000000000e3b6872d3d6a18f = textures/eq/cape/cotton_cape.png
-00000000a87e19c8e4f1713f = textures/eq/cape/leather_cape.png
-0000000091d4464202c02228 = textures/eq/cape/wind_cape.png
-000000003bf2557008f71ae6 = textures/eq/cape/wing_cape.png
+# Capes
+000000000e3b6872db5195e4 = textures/eq/cape/cotton_cape.png
+00000000a87e19c8c2570db0 = textures/eq/cape/leather_cape.png
+0000000091d44642aca021d1 = textures/eq/cape/wind_cape.png
+000000003bf255709e017edc = textures/eq/cape/wing_cape.png
 
-#Javelins#
-#All created by Xandis/Gat235
-000000008e92cd06e9ea1126 = textures/eq/javelin/wood_javelin.png
-00000000c5523867ef6bf615 = textures/eq/javelin/iron_javelin.png
-00000000d361b42f845e5e7a = textures/eq/javelin/steel_javelin.png
-000000007cee86f140c723bd = textures/eq/javelin/fire_javelin.png
-0000000093dcf20eeba46414 = textures/eq/javelin/piercing_javelin.png
-00000000698bb1656ee14bd2 = textures/eq/javelin/ancient_javelin.png
-000000004140ce4363063f18 = textures/eq/javelin/giant_javelin.png
-0000000098b0dff753b82631 = textures/eq/javelin/divine_javelin.png
-000000008fb386c71c0caa92 = textures/eq/javelin/ice_javelin.png
-0000000088936db4a21462a9 = textures/eq/javelin/dream_javelin.png
-000000005fd8def028cf7cd1 = textures/eq/javelin/thunder_javelin.png
-000000002daba71aac8e83d1 = textures/eq/javelin/great_fire_javelin.png
-00000000a8aa6ad40f8b4bb3 = textures/eq/javelin/great_ice_javelin.png
-000000001911e91f35c38d70 = textures/eq/javelin/great_thunder_javelin.png
-00000000037a95c068bab9fb = textures/eq/javelin/heaven_javelin.png
-00000000aae93a7b23b954f6 = textures/eq/javelin/demon_javelin.png
-000000001175581065568d2f = textures/eq/javelin/friendship_javelin.png
+# Javelins
+# All created by Xandis/Gat235
+000000008e92cd06e921972b = textures/eq/javelin/wood_javelin.png
+00000000c5523867d04fc46e = textures/eq/javelin/iron_javelin.png
+00000000d361b42f08b7a019 = textures/eq/javelin/steel_javelin.png
+000000007cee86f1d2eae339 = textures/eq/javelin/fire_javelin.png
+0000000093dcf20e3d24c850 = textures/eq/javelin/piercing_javelin.png
+00000000698bb1651f43862b = textures/eq/javelin/ancient_javelin.png
+000000004140ce43617adec9 = textures/eq/javelin/giant_javelin.png
+0000000098b0dff7b6f465f2 = textures/eq/javelin/divine_javelin.png
+000000008fb386c7c70153b0 = textures/eq/javelin/ice_javelin.png
+0000000088936db42cea9aed = textures/eq/javelin/dream_javelin.png
+000000005fd8def0882b2d6f = textures/eq/javelin/thunder_javelin.png
+000000002daba71a7db5f7a9 = textures/eq/javelin/great_fire_javelin.png
+00000000a8aa6ad41a217894 = textures/eq/javelin/great_ice_javelin.png
+000000001911e91fe3cba954 = textures/eq/javelin/great_thunder_javelin.png
+00000000037a95c072d0f63c = textures/eq/javelin/heaven_javelin.png
+00000000aae93a7bab334182 = textures/eq/javelin/demon_javelin.png
+00000000117558101eac039b = textures/eq/javelin/friendship_javelin.png
 
-#Birds#
-#All created by Xandis/Gat235
-00000000f3a0d18c950f6c6e = textures/eq/bird/bird.png
-00000000fdeb51fa31321b6d = textures/eq/bird/fast_bird.png
-00000000281a6da14ff15bef = textures/eq/bird/tough_bird.png
-00000000dfb48860051b647f = textures/eq/bird/strong_bird.png
-00000000fcad386c5417fa00 = textures/eq/bird/red_bird.png
-00000000996ab64e84cb8e48 = textures/eq/bird/ancient_bird.png
-00000000baf4a00a2fd2349c = textures/eq/bird/garuda_bird.png
-00000000e06b71e7f997836e = textures/eq/bird/divine_bird.png
-000000004947ca1dba4e8dd9 = textures/eq/bird/blue_bird.png
-000000001714c54b37f26608 = textures/eq/bird/yellow_bird.png
-00000000b1d2a01f7034affa = textures/eq/bird/flame_bird.png
-00000000efb900c2c186a0bb = textures/eq/bird/thunder_bird.png
-0000000033bafc0f78b01d78 = textures/eq/bird/ice_bird.png
-0000000074f4bcb0a5333787 = textures/eq/bird/dragon_bird.png
-000000005da3a6282fe73760 = textures/eq/bird/heaven_bird.png
-000000009dc6c5d5171480a9 = textures/eq/bird/demon_bird.png
-000000002fcdfd83e2e4b45b = textures/eq/bird/friendship_bird.png
+# Birds
+# All created by Xandis/Gat235
+00000000f3a0d18c28e7a1ac = textures/eq/bird/bird.png
+00000000fdeb51fa62875752 = textures/eq/bird/fast_bird.png
+00000000281a6da1131fbe3c = textures/eq/bird/tough_bird.png
+00000000dfb48860f07d3eb1 = textures/eq/bird/strong_bird.png
+00000000fcad386caec5ac81 = textures/eq/bird/red_bird.png
+00000000996ab64eef94a250 = textures/eq/bird/ancient_bird.png
+00000000baf4a00a43aa7fa0 = textures/eq/bird/garuda_bird.png
+00000000e06b71e79e3c5970 = textures/eq/bird/divine_bird.png
+000000004947ca1d3608442b = textures/eq/bird/blue_bird.png
+000000001714c54b247df7d1 = textures/eq/bird/yellow_bird.png
+00000000b1d2a01f1a41d426 = textures/eq/bird/flame_bird.png
+00000000efb900c29555ebb7 = textures/eq/bird/thunder_bird.png
+0000000033bafc0f1aa39109 = textures/eq/bird/ice_bird.png
+0000000074f4bcb0b912e759 = textures/eq/bird/dragon_bird.png
+000000005da3a6289d6b6d1e = textures/eq/bird/heaven_bird.png
+000000009dc6c5d59d3fe285 = textures/eq/bird/demon_bird.png
+000000002fcdfd83f3d531a6 = textures/eq/bird/friendship_bird.png
 
-#Arms#
-000000002f2c530beb5ba831 = textures/eq/arm/brick_arm.png
-00000000010087312f86f9ff = textures/eq/arm/iron_arm.png
-00000000b5f69d4e83b73268 = textures/eq/arm/steel_arm.png
-00000000dd01da570b2f8570 = textures/eq/arm/burst_arm.png
-0000000061fb20a1fe0089b8 = textures/eq/arm/ancient_arm.png
-00000000ca2c5ace9438a1b3 = textures/eq/arm/sleepy_arm.png
+# Arms
+000000002f2c530bd122ddaa = textures/eq/arm/brick_arm.png
+0000000001008731d122ddaa = textures/eq/arm/iron_arm.png
+00000000b5f69d4ed122ddaa = textures/eq/arm/steel_arm.png
+00000000dd01da57d122ddaa = textures/eq/arm/burst_arm.png
+0000000061fb20a1d81efc93 = textures/eq/arm/ancient_arm.png
+00000000ca2c5ace70c557ff = textures/eq/arm/sleepy_arm.png
 
-#Staffs#
-000000004c0b1436a1d1990b = textures/eq/staff/wood_staff.png
-000000008857d02bf11c6968 = textures/eq/staff/iron_staff.png
-00000000a90a4158fd38aa18 = textures/eq/staff/silver_staff.png
-00000000eed096989e26a925 = textures/eq/staff/defense_staff.png
-#0000000036860bb92b839a66 = textures/eq/staff/fire_staff.png
-00000000d84295de55745aab = textures/eq/staff/soothing_staff.png
-#wip ancient staff
-00000000b1676e8383d772c0 = textures/eq/staff/ancient_staff.png
-0000000067258812caf94456 = textures/eq/staff/divine_staff.png
-#0000000071a1200cf6dc8df1 = textures/eq/staff/ice_staff.png
-#0000000035e93102dde9f9c1 = textures/eq/staff/healing_staff.png
-0000000019a3d6c7604a058d = textures/eq/staff/thunder_staff.png
-#000000002d841f5f8446faa9 = textures/eq/staff/great_fire_staff.png
-#000000002a3edbc6be28bf89 = textures/eq/staff/great_ice_staff.png
-00000000a069552e1cd02398 = textures/eq/staff/great_thunder_staff.png
-000000009669c893c0522894 = textures/eq/staff/heaven_staff.png
-00000000378f27d3c3e99c9e = textures/eq/staff/demon_staff.png
-#00000000b3c4994818d24a25 = textures/eq/staff/friendship_staff.png
+# Staffs
+000000004c0b143643c5ea3b = textures/eq/staff/wood_staff.png
+000000008857d02b8875df41 = textures/eq/staff/iron_staff.png
+00000000a90a41587771ab3f = textures/eq/staff/silver_staff.png
+00000000eed0969812b9ce74 = textures/eq/staff/defense_staff.png
+# 0000000036860bb916f22813 = textures/eq/staff/fire_staff.png
+00000000d84295decf7f01eb = textures/eq/staff/soothing_staff.png
+# wip ancient staff
+00000000b1676e83698acd15 = textures/eq/staff/ancient_staff.png
+00000000672588123f07e870 = textures/eq/staff/divine_staff.png
+# 0000000071a1200c0d43c9e3 = textures/eq/staff/ice_staff.png
+# 0000000035e9310277e47db6 = textures/eq/staff/healing_staff.png
+0000000019a3d6c7ea9d381c = textures/eq/staff/thunder_staff.png
+# 000000002d841f5f8fab2a49 = textures/eq/staff/great_fire_staff.png
+# 000000002a3edbc646096aa7 = textures/eq/staff/great_ice_staff.png
+00000000a069552ef86f7cd9 = textures/eq/staff/great_thunder_staff.png
+000000009669c893519e72a5 = textures/eq/staff/heaven_staff.png
+00000000378f27d39cb42d66 = textures/eq/staff/demon_staff.png
+# 00000000b3c499482f57ccff = textures/eq/staff/friendship_staff.png
 
-#Shoes#
-00000000604a5c9a265f1a57 = textures/eq/shoe/wood_shoe.png
-#000000005bd089494ec2db6b = textures/eq/shoe/leather_sandals.png
-#000000009919c3ee8de1a667 = textures/eq/shoe/glass_shoes.png
-00000000c5a932b314799086 = textures/eq/shoe/wind_shoes.png
-000000000261078aae954c4b = textures/eq/shoe/boots_of_strength.png
-000000001d863ee411ae608d = textures/eq/shoe/wing_shoes.png
+# Shoes
+00000000604a5c9ad122ddaa = textures/eq/shoe/wood_shoe.png
+# 000000005bd08949d122ddaa = textures/eq/shoe/leather_sandals.png
+# 000000009919c3eed122ddaa = textures/eq/shoe/glass_shoes.png
+00000000c5a932b3d122ddaa = textures/eq/shoe/wind_shoes.png
+000000000261078ad122ddaa = textures/eq/shoe/boots_of_strength.png
+000000001d863ee4d122ddaa = textures/eq/shoe/wing_shoes.png
 
-#--Units--#
-0000000099ced485e86fff75 = textures/chara/hatapon.png
-00000000fec462cf3ce842c3 = textures/chara/yumi_tate_yari.png
-00000000a80debf650dface9 = textures/chara/kibapon.png
-0000000077f01a8c1609c84a = textures/chara/dekapon.png
-#megapon texture is currently a placeholder
-00000000be4ba952264dcfe1 = textures/chara/megapon.png
-0000000064ddf21af061bf1c = textures/chara/toripon.png
-000000001beee1289e3bd738 = textures/chara/mahopon.png
-00000000a2656acc8d6a2db4 = textures/chara/robopon.png
-#--Characters--#
-#Patapons
-00000000d57bf6b3afd69508 = textures/chara/doomed_patapon.png
-0000000023d0936fc4c50ab6 = textures/chara/captive_patapon.png
-00000000ea20cf7e09a35470 = textures/chara/trapped_patapon.png
-000000002d341a95e4c4995f = textures/chara/trapped_hero.png
-00000000269454d8eab686dc = textures/chara/ton_chin_kan.png
-000000009f7ba47aa189f4e4 = textures/chara/ton_chin_kan_ending.png
-#00000000e7b6945bbe8f570d = textures/chara/hero.png
-00000000188d86a06a45dd96 = textures/chara/caravan.png
-00000000188d86a06a45dd96 = textures/chara/caravan.png
-00000000e77dfdcad91d9746 = textures/chara/battle_caravan.png
-00000000416b204d0b7fa26a = textures/chara/battle_meden.png
-#Ban
-#Don
-000000008b1ab149ba9c9a35 = textures/chara/hoshipon.png
-#Zigotons
-000000006a46753293cf78fa = textures/chara/yumiton.png
-000000009bbc082536355f5d = textures/chara/tateton.png
-00000000e66bcc716e7c067b = textures/chara/yariton.png
-0000000062384756d853bf0b = textures/chara/kibaton.png
-0000000045f9fdd05850189e = textures/chara/toriton.png
-#000000009ebc32fc8d94efcf = textures/chara/ally_gong.png
-0000000035758d0e63bcfd11 = textures/chara/tank_zigo.png
-#Karmen
-000000005db02ae5e32338c3 = textures/chara/yumimen.png
-000000006604dc5b4ba1554a = textures/chara/tatemen.png
-0000000012232b763882381d = textures/chara/yarimen.png
-000000002bd211f6388d72fc = textures/chara/kibamen.png
-0000000006281f0efe1303ac = textures/chara/dekamen.png
-00000000cf6bb1362f89d214 = textures/chara/mahomen.png
-00000000f3343a211c452277 = textures/chara/robomen.png
-00000000a2a62866473f9392 = textures/chara/torimen.png
-000000004c58d4e4c3529cbe = textures/chara/zugagang_karmen.png
-#Sasorian/Akumapons
-00000000a108a2c762bfa050 = textures/chara/yumitan.png
-00000000c27f3949ebc27706 = textures/chara/tatetan.png
-00000000a108a2c72dc30da3 = textures/chara/yaritan.png
-0000000004613d3047d764ba = textures/chara/kibatan.png
-#00000000208404af0444a4f5 = textures/chara/megatan.png
-0000000036e49500dc7adc5e = textures/chara/dekatan.png
-#wip
-0000000016dad41eae911bf5 = textures/chara/black_hoshipon.png
+# --Units--
+0000000099ced48562afe69b = textures/chara/hatapon.png
+00000000fec462cfe93dc795 = textures/chara/yumi_tate_yari.png
+00000000a80debf6a6b8b2e8 = textures/chara/kibapon.png
+0000000077f01a8c4d8cac62 = textures/chara/dekapon.png
+# megapon texture is currently a placeholder
+00000000be4ba952d93c64d2 = textures/chara/megapon.png
+0000000064ddf21a337ed0ec = textures/chara/toripon.png
+000000001beee1284125d065 = textures/chara/mahopon.png
+00000000a2656acc05a170fb = textures/chara/robopon.png
+# --Characters--
+# Patapons
+00000000d57bf6b396764e36 = textures/chara/doomed_patapon.png
+0000000023d0936fcd8f0a52 = textures/chara/captive_patapon.png
+00000000ea20cf7ee54c9b78 = textures/chara/trapped_patapon.png
+000000002d341a954ef75be7 = textures/chara/trapped_hero.png
+00000000269454d87167e885 = textures/chara/ton_chin_kan.png
+000000009f7ba47a9fe4417e = textures/chara/ton_chin_kan_ending.png
+# 00000000e7b6945b426f8fe2 = textures/chara/hero.png
+00000000188d86a00df14fac = textures/chara/caravan.png
+# HASH_TO_UPDATE_00000000188d86a06a45dd96 = textures/chara/caravan.png
+# HASH_TO_UPDATE_00000000e77dfdcad91d9746 = textures/chara/battle_caravan.png
+00000000416b204dff577e62 = textures/chara/battle_meden.png
+# Ban
+# Don
+000000008b1ab14968655d57 = textures/chara/hoshipon.png
+# Zigotons
+000000006a467532c5e5fe60 = textures/chara/yumiton.png
+000000009bbc08250e81cd31 = textures/chara/tateton.png
+00000000e66bcc71360a62b8 = textures/chara/yariton.png
+000000006238475673c69057 = textures/chara/kibaton.png
+0000000045f9fdd0562da848 = textures/chara/toriton.png
+# 000000009ebc32fc5a86f64a = textures/chara/ally_gong.png
+0000000035758d0e50257c05 = textures/chara/tank_zigo.png
+# Karmen
+000000005db02ae58450474c = textures/chara/yumimen.png
+000000006604dc5bb0d79143 = textures/chara/tatemen.png
+0000000012232b76765f5f23 = textures/chara/yarimen.png
+000000002bd211f68cb57547 = textures/chara/kibamen.png
+0000000006281f0e68991c90 = textures/chara/dekamen.png
+00000000cf6bb136660445c3 = textures/chara/mahomen.png
+00000000f3343a212475272f = textures/chara/robomen.png
+00000000a2a62866cae18aed = textures/chara/torimen.png
+000000004c58d4e44dcfb2af = textures/chara/zugagang_karmen.png
+# Sasorian/Akumapons
+# HASH_TO_UPDATE_00000000a108a2c762bfa050 = textures/chara/yumitan.png
+00000000c27f3949be17957b = textures/chara/tatetan.png
+00000000a108a2c79388f4a7 = textures/chara/yaritan.png
+0000000004613d30e820def0 = textures/chara/kibatan.png
+# 00000000208404af456bc495 = textures/chara/megatan.png
+0000000036e495002e6731b5 = textures/chara/dekatan.png
+# wip
+0000000016dad41e804d43c4 = textures/chara/black_hoshipon.png
 
-#--Animals--#
+# --Animals--
 
-#--Bosses--#
-00000000acc729e95281e6f8 = textures/chara/dodonga.png
+# --Bosses--
+00000000acc729e9b16377e5 = textures/chara/dodonga.png
 
-#--Trophies--#
-00000000e45a195182e5b5b3 = textures/trophy/dodongas_head.png
+# --Trophies--
+00000000e45a1951f451ec62 = textures/trophy/dodongas_head.png
 
-#--Gimmicks--#
-000000006f749fd071106979 = textures/gimmick/balcony.png
-#chest made by Mitsuki
-00000000086e0183f436c6cf = textures/gimmick/chest.png
-00000000569980f2e5edf8d8 = textures/gimmick/grave.png
-00000000da7d4de8133e8567 = textures/gimmick/cannonball.png
-000000000fd9898869e9a49c = textures/gimmick/giant_cannonball.png
-00000000a9585782e7238929 = textures/gimmick/sokshi_cannonball.png
-000000000c321b490f7b1b4f = textures/gimmick/catapult.png
-00000000397ad2a421e7c7df = textures/gimmick/cata_rock.png
-00000000cdcf2d7678d29c25 = textures/gimmick/robo_rock.png
+# --Gimmicks--
+000000006f749fd09fc47341 = textures/gimmick/balcony.png
+# chest made by Mitsuki
+00000000086e0183c0df259c = textures/gimmick/chest.png
+00000000569980f28ddceb64 = textures/gimmick/grave.png
+00000000da7d4de820314001 = textures/gimmick/cannonball.png
+000000000fd989885c26707a = textures/gimmick/giant_cannonball.png
+00000000a95857829ea0a494 = textures/gimmick/sokshi_cannonball.png
+000000000c321b495f21d303 = textures/gimmick/catapult.png
+00000000397ad2a4309f91ea = textures/gimmick/cata_rock.png
+00000000cdcf2d7676b34a13 = textures/gimmick/robo_rock.png
 
 
-#--Backgrounds--#
-00000000da06045089006a01 = textures/bg/basin.png
-00000000ef3fd604c6355920 = textures/bg/cloudsea.png
-0000000040ed66bab180ee53 = textures/bg/crater.png
-000000002208e563aa88c0ec = textures/bg/forest.png
-00000000e6b24bb38b312054 = textures/bg/hills.png
-000000000f5767362164a7b6 = textures/bg/hot_desert.png
-00000000d416eb01dbf4c6ba = textures/bg/kingdom.png
-00000000fa81f467b87ea959 = textures/bg/mountain.png
-00000000887be988a26bf3dd = textures/bg/palace.png
-000000004eb184e274b609a2 = textures/bg/ravine.png
-00000000da76ca2b8e272606 = textures/bg/ruin.png
-00000000dea55233998c1a4b = textures/bg/sky_castle.png
-000000004aed43677c6c15ef = textures/bg/snowy.png
-0000000084b2a50f2c543725 = textures/bg/swamp.png
-0000000091556e36f8446217 = textures/bg/wasteland.png
-#0000000072e7e1b1f638c0cb = textures/bg/grassy.png
+# --Backgrounds--
+00000000da0604505091ec81 = textures/bg/basin.png
+00000000ef3fd604c81a30ec = textures/bg/cloudsea.png
+0000000040ed66ba88e26993 = textures/bg/crater.png
+000000002208e5630161138e = textures/bg/forest.png
+00000000e6b24bb39f72dfee = textures/bg/hills.png
+000000000f5767366365c3a2 = textures/bg/hot_desert.png
+00000000d416eb014fda2f0a = textures/bg/kingdom.png
+00000000fa81f467fcb118cf = textures/bg/mountain.png
+00000000887be988803ccbe9 = textures/bg/palace.png
+000000004eb184e2931a025c = textures/bg/ravine.png
+00000000da76ca2bfd9deb5f = textures/bg/ruin.png
+00000000dea552333af80e14 = textures/bg/sky_castle.png
+000000004aed4367efb3c7ff = textures/bg/snowy.png
+0000000084b2a50f006b88c9 = textures/bg/swamp.png
+0000000091556e36306f9a2b = textures/bg/wasteland.png
+# 0000000072e7e1b13d3d90f9 = textures/bg/grassy.png
 
-#Miracles
-00000000aa4f1d323878b448 = textures/bg/rain_statue.png
-000000008c7cbb63c3919eac = textures/bg/rain_OL_1.png
-0000000021117c5195a55568 = textures/bg/rain_OL_2.png
-000000009ee3640d882fe255 = textures/bg/wind_statue.png
-000000001373777c5ebda7c9 = textures/bg/wind_OL_1.png
-000000001ba2103427077980 = textures/bg/wind_OL_2.png
-00000000c7053a9d4f0f3030 = textures/bg/storm_statue.png
-0000000018e50d1ee4d01fbe = textures/bg/storm_OL_1.png
-000000000dd326252194cffe = textures/bg/storm_OL_2.png 
-00000000acf0bd09ef9bb6cd = textures/bg/earthquake_statue.png
-000000002bf94433e1d6ead9 = textures/bg/earthquake_OL_1.png
-00000000aaa8a6079eb56dea = textures/bg/earthquake_OL_2.png
-000000004a67408d7a163c41 = textures/bg/snow_statue.png
-00000000f4feb41ba40939e1 = textures/bg/snow_OL_1.png
-00000000a56338753b36058c = textures/bg/snow_OL_2.png
-0000000096eceead3dc7d562 = textures/bg/attack_statue.png
-000000000794bf07a1b22c88 = textures/bg/attack_OL_1.png
-00000000eb4eade520fc70b8 = textures/bg/attack_OL_2.png
-00000000493cf2d2bed9eccc = textures/bg/defense_statue.png
-00000000ee25cc4cf38f5ed0 = textures/bg/defense_OL_1.png
-00000000a7fc293523e8523f = textures/bg/defense_OL_2.png
+# Miracles
+00000000aa4f1d324ba0fc34 = textures/bg/rain_statue.png
+000000008c7cbb632881a387 = textures/bg/rain_OL_1.png
+0000000021117c51fc38dbd6 = textures/bg/rain_OL_2.png
+000000009ee3640de65a2adc = textures/bg/wind_statue.png
+000000001373777c0561a832 = textures/bg/wind_OL_1.png
+000000001ba21034bb755be6 = textures/bg/wind_OL_2.png
+# HASH_TO_UPDATE_00000000c7053a9d4f0f3030 = textures/bg/storm_statue.png
+# HASH_TO_UPDATE_0000000018e50d1ee4d01fbe = textures/bg/storm_OL_1.png
+# HASH_TO_UPDATE_000000000dd326252194cffe = textures/bg/storm_OL_2.png 
+# HASH_TO_UPDATE_00000000acf0bd09ef9bb6cd = textures/bg/earthquake_statue.png
+# HASH_TO_UPDATE_000000002bf94433e1d6ead9 = textures/bg/earthquake_OL_1.png
+# HASH_TO_UPDATE_00000000aaa8a6079eb56dea = textures/bg/earthquake_OL_2.png
+000000004a67408d6a2e03b3 = textures/bg/snow_statue.png
+00000000f4feb41b98b8892f = textures/bg/snow_OL_1.png
+00000000a56338754222affa = textures/bg/snow_OL_2.png
+0000000096eceeada55a4347 = textures/bg/attack_statue.png
+000000000794bf0756988d1e = textures/bg/attack_OL_1.png
+00000000eb4eade5cae60758 = textures/bg/attack_OL_2.png
+00000000493cf2d2bbbfddb2 = textures/bg/defense_statue.png
+00000000ee25cc4cee5c4a1b = textures/bg/defense_OL_1.png
+00000000a7fc29358e74c967 = textures/bg/defense_OL_2.png
 
-#Donchaka
-00000000e8d565fd9a56e7de = textures/bg/session_background.png
-0000000000c950d3aa9a0ed0 = textures/bg/session_background_OL.png
-#000000005032611f221ce07a = textures/gimmick/session_glow.png
-000000004450ad21a258b20e = textures/gimmick/session_flower.png
-00000000887c3ff926517314 = textures/gimmick/session_altar.png
-0000000056a3824725e39ea7 = textures/gimmick/session_dancer.png
-00000000c67a8c5690bcb479 = textures/gimmick/presession_altar.png
-00000000cd6fb070a258b20e = textures/gimmick/presession_flower.png
-#0000000005553b842ffdc308 = textures/gimmick/session_don.png
-#00000000d825d37a7e8643c0 = textures/gimmick/session_chaka.png
-#00000000f0775579f514ac57 = textures/gimmick/session_pon.png
-#0000000030716af45b6514d5 = textures/gimmick/session_pata.png
-0000000069df000eab463395 = textures/ui/session_drums.png
-0000000029f867da914cc5fb = textures/ui/session_mystery.png
-000000007cb5cee32e42218a = textures/ui/session_marker.png
-#00000000ae8095ec24a40098 = textures/ui/session_hit.png
+# Donchaka
+00000000e8d565fd61006acf = textures/bg/session_background.png
+0000000000c950d38c4eb2f6 = textures/bg/session_background_OL.png
+# 000000005032611fa66402d8 = textures/gimmick/session_glow.png
+000000004450ad21e593039d = textures/gimmick/session_flower.png
+00000000887c3ff9406596ee = textures/gimmick/session_altar.png
+0000000056a38247a9b29fb9 = textures/gimmick/session_dancer.png
+00000000c67a8c56db4f69fe = textures/gimmick/presession_altar.png
+00000000cd6fb070e593039d = textures/gimmick/presession_flower.png
+# 0000000005553b84909a4c63 = textures/gimmick/session_don.png
+# 00000000d825d37a406402a6 = textures/gimmick/session_chaka.png
+# 00000000f077557980805f29 = textures/gimmick/session_pon.png
+# 0000000030716af40b2fdd71 = textures/gimmick/session_pata.png
+0000000069df000e303ed911 = textures/ui/session_drums.png
+0000000029f867da900123c4 = textures/ui/session_mystery.png
+# HASH_TO_UPDATE_000000007cb5cee32e42218a = textures/ui/session_marker.png
+# 00000000ae8095ec2df8a5ae = textures/ui/session_hit.png


### PR DESCRIPTION
Update hashes using `reduceHash=True`.

Making use of reduce hash avoids having to hardcode the offsets, like this:
```ini
[hashranges]
# Loading tips
0x09cdee00,512,512 = 480,272
0x09ce1e40,512,512 = 480,272
...
```

37 hashes remain to be updated.